### PR TITLE
C# plugin 2.0.2: non-finite sensor handling + kernel-driver/elevation diagnostics

### DIFF
--- a/csharp-plugin/Launcher/Launcher.csproj
+++ b/csharp-plugin/Launcher/Launcher.csproj
@@ -11,7 +11,7 @@
     <PublishTrimmed>true</PublishTrimmed>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <AssemblyName>TouchPortalHardwareMonitor-Launcher</AssemblyName>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
   </PropertyGroup>
 
 </Project>

--- a/csharp-plugin/TouchPortalHardwareMonitor/Models/HardwareModels.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Models/HardwareModels.cs
@@ -34,6 +34,9 @@ public class SensorItem
     public string Name { get; set; } = string.Empty;
     public string SensorType { get; set; } = string.Empty;
     public float Value { get; set; }
+    // False when LibreHardwareMonitor reported the sensor but had no readable
+    // value (Value == null); Value is then NaN. Used only by the diagnostic dump.
+    public bool ValuePresent { get; set; } = true;
     public float? Min { get; set; }
     public float? Max { get; set; }
     public string? Unit { get; set; }
@@ -56,6 +59,17 @@ public class DiagnosticDump
 
     [JsonPropertyName("pluginVersion")]
     public string PluginVersion { get; set; } = string.Empty;
+
+    // Whether the plugin process is running elevated. The LibreHardwareMonitor
+    // kernel driver (WinRing0) only loads when elevated, so this is the first
+    // thing to check when CPU/motherboard sensors are missing.
+    [JsonPropertyName("isElevated")]
+    public bool IsElevated { get; set; }
+
+    // Human-readable summary of whether MSR/SuperIO sensors are accessible
+    // (i.e. whether the kernel driver appears to have loaded).
+    [JsonPropertyName("sensorAccess")]
+    public string SensorAccess { get; set; } = string.Empty;
 
     [JsonPropertyName("settings")]
     public DiagnosticSettings Settings { get; set; } = new();
@@ -137,6 +151,11 @@ public class DiagnosticSensor
 
     [JsonPropertyName("rawValue")]
     public float RawValue { get; set; }
+
+    // False when LHM reported this sensor but couldn't read a value (RawValue
+    // is NaN). Many null CPU/motherboard sensors => kernel driver didn't load.
+    [JsonPropertyName("valuePresent")]
+    public bool ValuePresent { get; set; } = true;
 
     [JsonPropertyName("convertedValue")]
     public float? ConvertedValue { get; set; }

--- a/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net.NetworkInformation;
+using System.Security.Principal;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using TouchPortalHardwareMonitor.Models;
@@ -22,6 +23,10 @@ class Program
 
     // Log level - read from loglevel.txt at startup
     private static bool _debugLogging = false;
+
+    // Whether the process is running elevated (administrator). The
+    // LibreHardwareMonitor kernel driver (WinRing0) only loads when elevated.
+    private static bool _isElevated = false;
 
     // Persistent hardware identifier to index mapping
     private static Dictionary<string, HardwareMapping> _hardwareMapping = new();
@@ -91,7 +96,9 @@ class Program
             var dump = new DiagnosticDump
             {
                 Timestamp = DateTime.Now.ToString("o"),
-                PluginVersion = "2.0.1",
+                PluginVersion = "2.0.2",
+                IsElevated = _isElevated,
+                SensorAccess = DetectSensorAccessStatus(rawSensorData).Message,
                 Settings = new DiagnosticSettings
                 {
                     CaptureInterval = _captureInterval,
@@ -155,6 +162,7 @@ class Program
                     Name = sensor.Name,
                     SensorType = sensor.SensorType,
                     RawValue = sensor.Value,
+                    ValuePresent = sensor.ValuePresent,
                     Min = sensor.Min,
                     Max = sensor.Max,
                     Matched = matched
@@ -264,6 +272,58 @@ class Program
         { "Humidity", "%" }
     };
 
+    private static bool IsProcessElevated()
+    {
+        try
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return false;
+            }
+            using var identity = WindowsIdentity.GetCurrent();
+            var principal = new WindowsPrincipal(identity);
+            return principal.IsInRole(WindowsBuiltInRole.Administrator);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    // Infers whether the LibreHardwareMonitor kernel driver loaded by checking
+    // for readable CPU temperature. CPU temp/clock/voltage and motherboard
+    // sensors come from MSR/SuperIO reads that require the driver; GPU (NVAPI),
+    // storage (SMART) and OS load/memory do not. A CPU with no readable
+    // temperature is the reliable signal that the driver did not load.
+    private static (bool Healthy, string Message) DetectSensorAccessStatus(List<SensorItem> sensors)
+    {
+        bool cpuPresent = _hardware.Values.Any(h => h.HardwareType == "CPU")
+            || _hardwareMapping.Values.Any(m => m.HardwareType.Equals("CPU", StringComparison.OrdinalIgnoreCase));
+
+        if (!cpuPresent)
+        {
+            return (true, "OK (no CPU detected to verify)");
+        }
+
+        bool cpuHasTemperature = sensors.Any(s =>
+            s.SensorType == "Temperature"
+            && s.ValuePresent
+            && s.Parent.Contains("cpu", StringComparison.OrdinalIgnoreCase));
+
+        if (cpuHasTemperature)
+        {
+            return (true, "OK - CPU sensors accessible");
+        }
+
+        var message = _isElevated
+            ? "CPU temperature/clock/voltage and motherboard sensors are unavailable even though the plugin is running as administrator. "
+              + "The LibreHardwareMonitor kernel driver (WinRing0) was blocked from loading - most likely Windows Core Isolation > Memory Integrity is ON, "
+              + "or antivirus / another monitoring app (HWiNFO, MSI Afterburner, Armoury Crate, OpenRGB, Ryzen Master) is holding the driver."
+            : "CPU temperature/clock/voltage and motherboard sensors are unavailable because the plugin is NOT running as administrator, "
+              + "so the LibreHardwareMonitor kernel driver could not load. Accept the UAC prompt when the plugin starts, or run Touch Portal as administrator.";
+        return (false, message);
+    }
+
     private static void LoadHardwareMapping()
     {
         try
@@ -353,10 +413,18 @@ class Program
 
     static async Task Main(string[] args)
     {
-        Log("Touch Portal Hardware Monitor v2.0.1 starting...");
+        Log("Touch Portal Hardware Monitor v2.0.2 starting...");
 
         // Initialize log level from file (before anything else)
         InitializeLogLevel();
+
+        // Record elevation - CPU/motherboard sensors depend on it
+        _isElevated = IsProcessElevated();
+        Log($"Running as administrator (elevated): {_isElevated}");
+        if (!_isElevated)
+        {
+            Log("WARNING: Not elevated. CPU temperature/clock/voltage and motherboard sensors will be unavailable because the LibreHardwareMonitor kernel driver cannot load.");
+        }
 
         // Check if a sensor dump was requested
         CheckDumpTrigger();
@@ -592,7 +660,11 @@ class Program
             // Write diagnostic dump if requested
             if (_dumpRequested)
             {
-                WriteDiagnosticDump(hardwareData, sensorData!, hardwareWithSensors, activeNetworkAdapters);
+                // Use the diagnostic collection so sensors LHM couldn't read
+                // (null values, e.g. CPU temp when the driver didn't load) show
+                // up in the dump instead of silently disappearing.
+                var diagnosticSensors = _hwService?.GetSensorsForDiagnostics() ?? sensorData!;
+                WriteDiagnosticDump(hardwareData, diagnosticSensors, hardwareWithSensors, activeNetworkAdapters);
                 _dumpRequested = false;
             }
 
@@ -729,8 +801,34 @@ class Program
             var isFirstCapture = _firstCapture;
             _firstCapture = false;
 
+            // On first capture, check whether MSR/SuperIO sensors are accessible
+            // (i.e. whether the kernel driver loaded) and warn if not.
+            (bool Healthy, string Message) sensorAccess = (true, "OK");
+            if (isFirstCapture)
+            {
+                sensorAccess = DetectSensorAccessStatus(sensorData);
+                if (!sensorAccess.Healthy)
+                {
+                    Log($"[SensorAccess] {sensorAccess.Message}");
+                    _tpClient?.LogIt("WARN", sensorAccess.Message);
+                }
+            }
+
             var newStates = new List<TPStateDefinition>();
             var stateUpdates = new List<TPStateValue>();
+
+            // Publish a plugin status state users can display on a button so they
+            // can self-diagnose missing CPU/motherboard sensors without a dump.
+            if (isFirstCapture)
+            {
+                newStates.Add(new TPStateDefinition
+                {
+                    Id = "tp-hm.state.plugin.sensor_status",
+                    Desc = "TP Hardware Monitor > Plugin > Sensor Access Status",
+                    DefaultValue = sensorAccess.Message,
+                    ParentGroup = "TP Hardware Monitor"
+                });
+            }
 
             foreach (var sensor in sensorData)
             {

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/HardwareMonitorService.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/HardwareMonitorService.cs
@@ -50,14 +50,22 @@ public class HardwareMonitorService : IDisposable
         }
     }
 
-    public List<SensorItem> GetSensors()
+    public List<SensorItem> GetSensors() => CollectAll(includeValueless: false);
+
+    // Diagnostic variant: also includes sensors LHM created but couldn't read
+    // (Value == null). A CPU/motherboard whose sensors all come back null is the
+    // tell-tale of a kernel driver (WinRing0/Ring0) that failed to load - the
+    // live path filters these out, so the dump needs them to diagnose the cause.
+    public List<SensorItem> GetSensorsForDiagnostics() => CollectAll(includeValueless: true);
+
+    private List<SensorItem> CollectAll(bool includeValueless)
     {
         var result = new List<SensorItem>();
-        CollectSensors(_computer.Hardware, result);
+        CollectSensors(_computer.Hardware, result, includeValueless);
         return result;
     }
 
-    private void CollectSensors(IEnumerable<IHardware> hardwareList, List<SensorItem> result)
+    private void CollectSensors(IEnumerable<IHardware> hardwareList, List<SensorItem> result, bool includeValueless)
     {
         foreach (var hardware in hardwareList)
         {
@@ -65,24 +73,28 @@ public class HardwareMonitorService : IDisposable
 
             foreach (var sensor in hardware.Sensors)
             {
-                if (sensor.Value.HasValue)
+                var hasValue = sensor.Value.HasValue;
+                if (!hasValue && !includeValueless)
                 {
-                    result.Add(new SensorItem
-                    {
-                        Parent = hardware.Identifier.ToString(),
-                        Identifier = sensor.Identifier.ToString(),
-                        Name = sensor.Name,
-                        SensorType = sensor.SensorType.ToString(),
-                        Value = sensor.Value.Value,
-                        Min = sensor.Min,
-                        Max = sensor.Max
-                    });
+                    continue;
                 }
+
+                result.Add(new SensorItem
+                {
+                    Parent = hardware.Identifier.ToString(),
+                    Identifier = sensor.Identifier.ToString(),
+                    Name = sensor.Name,
+                    SensorType = sensor.SensorType.ToString(),
+                    Value = hasValue ? sensor.Value!.Value : float.NaN,
+                    ValuePresent = hasValue,
+                    Min = sensor.Min,
+                    Max = sensor.Max
+                });
             }
 
             if (hardware.SubHardware.Length > 0)
             {
-                CollectSensors(hardware.SubHardware, result);
+                CollectSensors(hardware.SubHardware, result, includeValueless);
             }
         }
     }

--- a/csharp-plugin/TouchPortalHardwareMonitor/TouchPortalHardwareMonitor.csproj
+++ b/csharp-plugin/TouchPortalHardwareMonitor/TouchPortalHardwareMonitor.csproj
@@ -13,11 +13,11 @@
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AssemblyName>TouchPortalHardwareMonitor</AssemblyName>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp-plugin/TouchPortalHardwareMonitor/entry.tp
+++ b/csharp-plugin/TouchPortalHardwareMonitor/entry.tp
@@ -1,6 +1,6 @@
 {
   "sdk": 6,
-  "version": 2001,
+  "version": 2002,
   "name": "Touch Portal Hardware Monitor",
   "id": "TP_HM",
   "plugin_start_cmd": "\"%TP_PLUGIN_FOLDER%TouchPortalHardwareMonitor\\TouchPortalHardwareMonitor-Launcher.exe\"",

--- a/csharp-plugin/build.ps1
+++ b/csharp-plugin/build.ps1
@@ -8,7 +8,7 @@ $publishDir = "$projectDir\bin\Release\net10.0\win-x64\publish"
 $launcherPublishDir = "$launcherDir\bin\Release\net10.0\win-x64\publish"
 $installersDir = "$PSScriptRoot\Installers"
 $pluginName = "TouchPortalHardwareMonitor"
-$version = "2.0.1"
+$version = "2.0.2"
 
 Write-Host "Building Touch Portal Hardware Monitor C# Plugin v$version..." -ForegroundColor Cyan
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "touchportal-hardwaremonitor",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Touch Portal plugin to read data from LibreHardwareMonitor",
   "main": "src/index.js",
   "bin": "src/index.js",


### PR DESCRIPTION
Cumulative PR for the C# plugin work, targeting `main`. Contains three commits (2.0.0 → 2.0.1 → 2.0.2).

## Commits
1. **2.0.0** — C# rewrite with LibreHardwareMonitor bridge (self-contained, elevated launcher).
2. **2.0.1** — Handle non-finite sensor values.
3. **2.0.2** — Kernel-driver / elevation diagnostics.

## 2.0.1 — non-finite sensor values
Sensors can report `Infinity`/`NaN` (e.g. network utilization ÷ 0 link speed on phantom adapters). This crashed the diagnostic dump mid-write (System.Text.Json throws on non-finite floats → truncated, invalid file) and could push `"Infinity"`/`"NaN"` state values to Touch Portal that never clear.
- `JsonContext`: allow named floating-point literals so the dump stays valid
- `CaptureAsync`: skip non-finite values before sending to Touch Portal
- Guard `min`/`max` with `float.IsFinite`

## 2.0.2 — kernel-driver / elevation diagnostics
Multiple Win11 users reported missing CPU (sometimes GPU) temperatures. Dumps showed a consistent signature: CPU **Load** present, CPU **Power** present but `0 W`, CPU **temperature/clock/voltage absent**, **motherboard sensors absent** — while GPU (NVAPI), storage (SMART) and OS load/memory all worked. That split means LibreHardwareMonitor's Ring0 kernel driver (WinRing0) didn't load: not elevated, or blocked by Memory Integrity / antivirus / another monitoring app.

The plugin previously gave no way to tell these apart, and the dump hid the evidence by filtering out null-valued sensors.

- Detect + log process elevation at startup; record `isElevated` in the dump
- `DetectSensorAccessStatus` heuristic (CPU present but no readable temp ⇒ driver not loaded) with an elevation-aware explanation
- Publish `tp-hm.state.plugin.sensor_status` so end users can see the problem on a button without a dump
- Include null-valued sensors in the dump (`GetSensorsForDiagnostics`, `valuePresent` flag); add `sensorAccess` summary
- Bump `LibreHardwareMonitorLib` 0.9.5 → 0.9.6
- Version → 2.0.2 (entry.tp `2002`, csprojs, package.json, build.ps1)

## Testing
- `dotnet build -c Release`: 0 warnings, 0 errors
- Packaged via `build.ps1` → `TouchPortalHardwareMonitor-Windows-2.0.2.tpp`
- Smoke-tested startup: elevation logging works, no crash

## Notes
- `.NET bin/obj` build artifacts and `.claude/settings.local.json` are gitignored; the `.tpp` lands in the gitignored `Installers/`.
- The LHM 0.9.6 bump may not by itself fix a driver blocked by Memory Integrity — that's environmental; the diagnostics confirm which case each user is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)