### PR TITLE
feat(csharp): apply capture-interval setting changes live

### DIFF
--- a/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
@@ -499,6 +499,9 @@ class Program
         LogDebug($"[Settings] HandleSettings called with {settings.Count} setting groups");
         LogDebug( "Received settings from Touch Portal");
 
+        // Remember the interval so we can re-arm the timer live if it changes
+        var previousInterval = _captureInterval;
+
         foreach (var setting in settings)
         {
             foreach (var kvp in setting)
@@ -538,6 +541,13 @@ class Program
         else
         {
             LogDebug("[Settings] Already capturing, skipping BuildHardwareList");
+
+            // Apply a changed capture interval live, without a plugin restart.
+            if (_captureInterval > 0 && _captureInterval != previousInterval && _captureTimer != null)
+            {
+                _captureTimer.Change(0, _captureInterval);
+                Log($"Capture interval changed live: {previousInterval}ms -> {_captureInterval}ms");
+            }
         }
     }
 


### PR DESCRIPTION
Small follow-up to #22 (which is now merged into `main`).

## Problem
The **Sensor Capture Time (ms)** setting was configurable but only took effect on plugin restart. `HandleSettings` updated `_captureInterval`, but once capturing had started it never re-armed the timer created in `StartCapture()`, so a changed value was stored and ignored until the next launch.

## Change
In `HandleSettings`, when already capturing and the interval actually changed, re-arm the running timer:

```csharp
if (_captureInterval > 0 && _captureInterval != previousInterval && _captureTimer != null)
{
    _captureTimer.Change(0, _captureInterval);
}
```

- Guarded on a positive, changed value and a non-null timer.
- `Timer.Change` is thread-safe; `dueTime: 0` triggers one immediate capture at the new cadence for instant feedback (matching how `StartCapture` arms it).
- No version bump — behaviorally additive on top of the 2.0.2 already in `main`.

## Testing
- `dotnet build -c Release`: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)