### PR TITLE
feat(csharp): display refresh-rate states (Win32, no LibreHardwareMonitor) — 2.1.0

### DIFF
--- a/csharp-plugin/Launcher/Launcher.csproj
+++ b/csharp-plugin/Launcher/Launcher.csproj
@@ -11,7 +11,7 @@
     <PublishTrimmed>true</PublishTrimmed>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <AssemblyName>TouchPortalHardwareMonitor-Launcher</AssemblyName>
-    <Version>2.0.2</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/csharp-plugin/TouchPortalHardwareMonitor/Models/HardwareModels.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Models/HardwareModels.cs
@@ -43,6 +43,17 @@ public class SensorItem
     public SensorStateInfo? StateId { get; set; }
 }
 
+// A connected display, sourced from Win32 (not LibreHardwareMonitor).
+public class DisplayInfo
+{
+    public int Index { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public bool IsPrimary { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
+    public int RefreshRateHz { get; set; }
+}
+
 public class SensorStateInfo
 {
     public string Id { get; set; } = string.Empty;

--- a/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
@@ -96,7 +96,7 @@ class Program
             var dump = new DiagnosticDump
             {
                 Timestamp = DateTime.Now.ToString("o"),
-                PluginVersion = "2.0.2",
+                PluginVersion = "2.1.0",
                 IsElevated = _isElevated,
                 SensorAccess = DetectSensorAccessStatus(rawSensorData).Message,
                 Settings = new DiagnosticSettings
@@ -413,7 +413,17 @@ class Program
 
     static async Task Main(string[] args)
     {
-        Log("Touch Portal Hardware Monitor v2.0.2 starting...");
+        // Quick standalone probe: list displays and exit (no TP connection).
+        if (args.Contains("--displays"))
+        {
+            foreach (var d in DisplayInfoService.GetDisplays())
+            {
+                Console.WriteLine($"Display {d.Index}{(d.IsPrimary ? " (Primary)" : "")}: {d.Width}x{d.Height} @ {d.RefreshRateHz} Hz - {d.Name}");
+            }
+            return;
+        }
+
+        Log("Touch Portal Hardware Monitor v2.1.0 starting...");
 
         // Initialize log level from file (before anything else)
         InitializeLogLevel();
@@ -780,6 +790,9 @@ class Program
     private static DateTime _lastCreateStateTime = DateTime.MinValue;
     private static readonly TimeSpan _createStateCooldown = TimeSpan.FromSeconds(5);
 
+    // Last-sent value per display state id, for change detection.
+    private static readonly Dictionary<string, string> _displayStateCache = new();
+
     private static async Task CaptureAsync()
     {
         try
@@ -1005,6 +1018,9 @@ class Program
                 }
             }
 
+            // Display states (refresh rate / resolution) - not from LibreHardwareMonitor
+            AddDisplayStates(newStates, stateUpdates);
+
             // Send state creates to Touch Portal
             LogDebug($"[Capture] newStates.Count = {newStates.Count}, stateUpdates.Count = {stateUpdates.Count}");
 
@@ -1154,6 +1170,60 @@ class Program
     private static string GetThroughputUnit(int count)
     {
         return GetDataUnit(count) + "/s";
+    }
+
+    // Build/refresh display states (refresh rate, resolution, name) sourced
+    // from Win32 - independent of LibreHardwareMonitor. New displays create
+    // states; changed values (e.g. a mode switch) push updates.
+    private static void AddDisplayStates(List<TPStateDefinition> newStates, List<TPStateValue> stateUpdates)
+    {
+        List<DisplayInfo> displays;
+        try
+        {
+            displays = DisplayInfoService.GetDisplays();
+        }
+        catch (Exception ex)
+        {
+            LogDebug($"[Display] Failed to enumerate displays: {ex.Message}");
+            return;
+        }
+
+        const string group = "Displays";
+
+        foreach (var d in displays)
+        {
+            var label = d.IsPrimary ? $"Display {d.Index} (Primary)" : $"Display {d.Index}";
+            var baseId = $"tp-hm.state.display.{d.Index}";
+
+            UpsertDisplayState(newStates, stateUpdates, $"{baseId}.refresh_rate", $"{group} > {label} > Refresh Rate (Hz)", group, d.RefreshRateHz.ToString());
+            UpsertDisplayState(newStates, stateUpdates, $"{baseId}.refresh_rate.unit", $"{group} > {label} > Refresh Rate Unit", group, "Hz");
+            UpsertDisplayState(newStates, stateUpdates, $"{baseId}.resolution", $"{group} > {label} > Resolution", group, $"{d.Width}x{d.Height}");
+            UpsertDisplayState(newStates, stateUpdates, $"{baseId}.name", $"{group} > {label} > Name", group, d.Name);
+            UpsertDisplayState(newStates, stateUpdates, $"{baseId}.primary", $"{group} > {label} > Is Primary", group, d.IsPrimary ? "true" : "false");
+        }
+
+        UpsertDisplayState(newStates, stateUpdates, "tp-hm.state.display.count", $"{group} > Display Count", group, displays.Count.ToString());
+    }
+
+    private static void UpsertDisplayState(List<TPStateDefinition> newStates, List<TPStateValue> stateUpdates,
+        string id, string desc, string group, string value)
+    {
+        if (!_displayStateCache.TryGetValue(id, out var existing))
+        {
+            _displayStateCache[id] = value;
+            newStates.Add(new TPStateDefinition
+            {
+                Id = id,
+                Desc = desc,
+                DefaultValue = value,
+                ParentGroup = group
+            });
+        }
+        else if (existing != value)
+        {
+            _displayStateCache[id] = value;
+            stateUpdates.Add(new TPStateValue { Id = id, Value = value });
+        }
     }
 
     private static void Shutdown()

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/DisplayInfoService.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/DisplayInfoService.cs
@@ -1,0 +1,121 @@
+using System.Runtime.InteropServices;
+using TouchPortalHardwareMonitor.Models;
+
+namespace TouchPortalHardwareMonitor.Services;
+
+/// <summary>
+/// Enumerates connected displays and their current mode (resolution +
+/// refresh rate) using Win32 display APIs. Deliberately independent of
+/// LibreHardwareMonitor - needs no kernel driver and no elevation.
+/// </summary>
+public static class DisplayInfoService
+{
+    public static List<DisplayInfo> GetDisplays()
+    {
+        var results = new List<DisplayInfo>();
+
+        var adapter = new DISPLAY_DEVICE();
+        adapter.cb = Marshal.SizeOf<DISPLAY_DEVICE>();
+
+        uint adapterIndex = 0;
+        int displayIndex = 0;
+
+        while (EnumDisplayDevices(null, adapterIndex, ref adapter, 0))
+        {
+            adapterIndex++;
+
+            // Only adapters actually driving the desktop have a live mode.
+            if ((adapter.StateFlags & DISPLAY_DEVICE_ATTACHED_TO_DESKTOP) != 0)
+            {
+                var mode = new DEVMODE();
+                mode.dmSize = (short)Marshal.SizeOf<DEVMODE>();
+
+                if (EnumDisplaySettings(adapter.DeviceName, ENUM_CURRENT_SETTINGS, ref mode))
+                {
+                    displayIndex++;
+
+                    // Prefer the attached monitor's friendly name over the adapter.
+                    var name = adapter.DeviceString;
+                    var monitor = new DISPLAY_DEVICE();
+                    monitor.cb = Marshal.SizeOf<DISPLAY_DEVICE>();
+                    if (EnumDisplayDevices(adapter.DeviceName, 0, ref monitor, 0)
+                        && !string.IsNullOrWhiteSpace(monitor.DeviceString))
+                    {
+                        name = monitor.DeviceString;
+                    }
+
+                    results.Add(new DisplayInfo
+                    {
+                        Index = displayIndex,
+                        Name = name,
+                        IsPrimary = (adapter.StateFlags & DISPLAY_DEVICE_PRIMARY_DEVICE) != 0,
+                        Width = (int)mode.dmPelsWidth,
+                        Height = (int)mode.dmPelsHeight,
+                        RefreshRateHz = (int)mode.dmDisplayFrequency
+                    });
+                }
+            }
+
+            // cb is overwritten by the call; reset before reusing the struct.
+            adapter = new DISPLAY_DEVICE { cb = Marshal.SizeOf<DISPLAY_DEVICE>() };
+        }
+
+        return results;
+    }
+
+    private const int ENUM_CURRENT_SETTINGS = -1;
+    private const uint DISPLAY_DEVICE_ATTACHED_TO_DESKTOP = 0x00000001;
+    private const uint DISPLAY_DEVICE_PRIMARY_DEVICE = 0x00000004;
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern bool EnumDisplayDevices(string? lpDevice, uint iDevNum, ref DISPLAY_DEVICE lpDisplayDevice, uint dwFlags);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern bool EnumDisplaySettings(string lpszDeviceName, int iModeNum, ref DEVMODE lpDevMode);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct DISPLAY_DEVICE
+    {
+        public int cb;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)] public string DeviceName;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)] public string DeviceString;
+        public uint StateFlags;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)] public string DeviceID;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)] public string DeviceKey;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct DEVMODE
+    {
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)] public string dmDeviceName;
+        public short dmSpecVersion;
+        public short dmDriverVersion;
+        public short dmSize;
+        public short dmDriverExtra;
+        public int dmFields;
+        public int dmPositionX;
+        public int dmPositionY;
+        public int dmDisplayOrientation;
+        public int dmDisplayFixedOutput;
+        public short dmColor;
+        public short dmDuplex;
+        public short dmYResolution;
+        public short dmTTOption;
+        public short dmCollate;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)] public string dmFormName;
+        public short dmLogPixels;
+        public int dmBitsPerPel;
+        public uint dmPelsWidth;
+        public uint dmPelsHeight;
+        public int dmDisplayFlags;
+        public uint dmDisplayFrequency;
+        public int dmICMMethod;
+        public int dmICMIntent;
+        public int dmMediaType;
+        public int dmDitherType;
+        public int dmReserved1;
+        public int dmReserved2;
+        public int dmPanningWidth;
+        public int dmPanningHeight;
+    }
+}

--- a/csharp-plugin/TouchPortalHardwareMonitor/TouchPortalHardwareMonitor.csproj
+++ b/csharp-plugin/TouchPortalHardwareMonitor/TouchPortalHardwareMonitor.csproj
@@ -13,7 +13,7 @@
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AssemblyName>TouchPortalHardwareMonitor</AssemblyName>
-    <Version>2.0.2</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp-plugin/TouchPortalHardwareMonitor/entry.tp
+++ b/csharp-plugin/TouchPortalHardwareMonitor/entry.tp
@@ -1,6 +1,6 @@
 {
   "sdk": 6,
-  "version": 2002,
+  "version": 2100,
   "name": "Touch Portal Hardware Monitor",
   "id": "TP_HM",
   "plugin_start_cmd": "\"%TP_PLUGIN_FOLDER%TouchPortalHardwareMonitor\\TouchPortalHardwareMonitor-Launcher.exe\"",

--- a/csharp-plugin/build.ps1
+++ b/csharp-plugin/build.ps1
@@ -8,7 +8,7 @@ $publishDir = "$projectDir\bin\Release\net10.0\win-x64\publish"
 $launcherPublishDir = "$launcherDir\bin\Release\net10.0\win-x64\publish"
 $installersDir = "$PSScriptRoot\Installers"
 $pluginName = "TouchPortalHardwareMonitor"
-$version = "2.0.2"
+$version = "2.1.0"
 
 Write-Host "Building Touch Portal Hardware Monitor C# Plugin v$version..." -ForegroundColor Cyan
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "touchportal-hardwaremonitor",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Touch Portal plugin to read data from LibreHardwareMonitor",
   "main": "src/index.js",
   "bin": "src/index.js",


### PR DESCRIPTION
Adds a **Displays** state category, sourced from Win32 display APIs — deliberately independent of LibreHardwareMonitor (no kernel driver, no elevation required). This is the "refresh rate" half of the FPS request; **rendered FPS via PresentMon is a planned follow-up** (see below).

## States (per connected display, parent group "Displays")
- `tp-hm.state.display.{n}.refresh_rate` — e.g. `144` (+ `.refresh_rate.unit` = `Hz`)
- `tp-hm.state.display.{n}.resolution` — e.g. `2560x1440`
- `tp-hm.state.display.{n}.name` — monitor friendly name
- `tp-hm.state.display.{n}.primary` — `true`/`false`
- `tp-hm.state.display.count` — number of active displays

## Implementation
- New `DisplayInfoService` — `EnumDisplayDevices` + `EnumDisplaySettings` P/Invoke, returns resolution + refresh rate per attached display.
- New `DisplayInfo` model.
- `AddDisplayStates` wired into the existing capture loop; states are created on first sight and updated on change (e.g. a mode switch), reusing the createState/stateUpdate flow.
- `--displays` CLI probe (`TouchPortalHardwareMonitor.exe --displays`) lists displays and exits — handy diagnostic.
- Version → 2.1.0 (entry.tp `2100`, csprojs, package.json, build.ps1).

## Testing
- `dotnet build -c Release`: 0 warnings, 0 errors.
- Ran `--displays` on a 2-monitor dev machine (non-elevated): correctly reported both `2560x1440 @ 144 Hz` and flagged the primary.
- Packaged `TouchPortalHardwareMonitor-Windows-2.1.0.tpp`.

## Follow-up: actual rendered FPS
The second half ("Both") — real frames-per-second of the foreground app via PresentMon/ETW — is intentionally not in this PR. It's a larger, per-process feature (ETW present-event capture) and warrants its own PR. Happy to do it next.

## Notes
- Display index is enumeration order (1..N), not persistent across hot-plug — acceptable for v1; can move to a persistent mapping (like hardware) later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)