### PR TITLE
feat(csharp): selectable FPS source — RTSS + in-process ETW (2.2.0)

### DIFF
--- a/csharp-plugin/Launcher/Launcher.csproj
+++ b/csharp-plugin/Launcher/Launcher.csproj
@@ -11,7 +11,7 @@
     <PublishTrimmed>true</PublishTrimmed>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <AssemblyName>TouchPortalHardwareMonitor-Launcher</AssemblyName>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
@@ -96,7 +96,7 @@ class Program
             var dump = new DiagnosticDump
             {
                 Timestamp = DateTime.Now.ToString("o"),
-                PluginVersion = "2.1.0",
+                PluginVersion = "2.2.0",
                 IsElevated = _isElevated,
                 SensorAccess = DetectSensorAccessStatus(rawSensorData).Message,
                 Settings = new DiagnosticSettings
@@ -423,7 +423,27 @@ class Program
             return;
         }
 
-        Log("Touch Portal Hardware Monitor v2.1.0 starting...");
+        // Quick standalone probe: sample FPS for ~10s and exit. Run elevated
+        // with a game in the foreground to test the ETW backend.
+        if (args.Contains("--fps"))
+        {
+            _isElevated = IsProcessElevated();
+            Console.WriteLine($"Elevated: {_isElevated}");
+            using var probe = new FpsService();
+            probe.Configure(FpsMode.Auto);
+            if (probe.EtwError != null) Console.WriteLine($"ETW backend error: {probe.EtwError}");
+            for (int i = 0; i < 10; i++)
+            {
+                await Task.Delay(1000);
+                var r = probe.GetForegroundFps();
+                Console.WriteLine(r.HasValue
+                    ? $"FPS={r.Value.Fps:F1}  source={r.Value.Source}  app={r.Value.ProcessName}"
+                    : "FPS=(none - no presenting app / backend unavailable)");
+            }
+            return;
+        }
+
+        Log("Touch Portal Hardware Monitor v2.2.0 starting...");
 
         // Initialize log level from file (before anything else)
         InitializeLogLevel();
@@ -458,6 +478,14 @@ class Program
             Log("Initializing LibreHardwareMonitor...");
             _hwService = new HardwareMonitorService();
             Log("LibreHardwareMonitor initialized successfully");
+
+            // Initialize FPS reporting (Auto by default; a setting may change it)
+            _fpsService = new FpsService();
+            _fpsService.Configure(_fpsMode);
+            if (_fpsService.EtwError != null)
+            {
+                Log($"FPS: in-process ETW backend unavailable ({_fpsService.EtwError}). RTSS will be used if it is running.");
+            }
 
             // Initialize Touch Portal client
             _tpClient = new TouchPortalClient(PluginId);
@@ -536,6 +564,15 @@ class Program
                         break;
                     case "Normalize Data (MB, GB)":
                         _normalizeData = kvp.Value;
+                        break;
+                    case "FPS Source (Off/RTSS/Built-in/Auto)":
+                        var newMode = FpsService.ParseMode(kvp.Value);
+                        if (newMode != _fpsMode)
+                        {
+                            _fpsMode = newMode;
+                            _fpsService?.Configure(_fpsMode);
+                            LogDebug($"[Settings] FPS source set to: {_fpsMode}");
+                        }
                         break;
                 }
             }
@@ -790,8 +827,12 @@ class Program
     private static DateTime _lastCreateStateTime = DateTime.MinValue;
     private static readonly TimeSpan _createStateCooldown = TimeSpan.FromSeconds(5);
 
-    // Last-sent value per display state id, for change detection.
+    // Last-sent value per display/FPS state id, for change detection.
     private static readonly Dictionary<string, string> _displayStateCache = new();
+
+    // FPS (frames-per-second) reporting - independent of LibreHardwareMonitor.
+    private static FpsService? _fpsService;
+    private static FpsMode _fpsMode = FpsMode.Auto;
 
     private static async Task CaptureAsync()
     {
@@ -1021,6 +1062,9 @@ class Program
             // Display states (refresh rate / resolution) - not from LibreHardwareMonitor
             AddDisplayStates(newStates, stateUpdates);
 
+            // FPS states (foreground app frame rate) - not from LibreHardwareMonitor
+            AddFpsStates(newStates, stateUpdates);
+
             // Send state creates to Touch Portal
             LogDebug($"[Capture] newStates.Count = {newStates.Count}, stateUpdates.Count = {stateUpdates.Count}");
 
@@ -1205,6 +1249,39 @@ class Program
         UpsertDisplayState(newStates, stateUpdates, "tp-hm.state.display.count", $"{group} > Display Count", group, displays.Count.ToString());
     }
 
+    // Build/refresh FPS states for the foreground app. Uses the configured
+    // FPS source (RTSS / in-process ETW / Auto); independent of LibreHardwareMonitor.
+    private static void AddFpsStates(List<TPStateDefinition> newStates, List<TPStateValue> stateUpdates)
+    {
+        if (_fpsService == null || _fpsMode == FpsMode.Off)
+        {
+            return;
+        }
+
+        FpsReading? reading;
+        try
+        {
+            reading = _fpsService.GetForegroundFps();
+        }
+        catch (Exception ex)
+        {
+            LogDebug($"[FPS] read failed: {ex.Message}");
+            return;
+        }
+
+        const string group = "FPS";
+        var value = reading.HasValue ? Math.Round(reading.Value.Fps).ToString("F0") : "0";
+        var app = reading?.ProcessName ?? "";
+        var source = reading?.Source ?? "";
+
+        UpsertDisplayState(newStates, stateUpdates, "tp-hm.state.fps.value", $"{group} > Current FPS", group, value);
+        UpsertDisplayState(newStates, stateUpdates, "tp-hm.state.fps.unit", $"{group} > Current FPS Unit", group, "FPS");
+        UpsertDisplayState(newStates, stateUpdates, "tp-hm.state.fps.process", $"{group} > Foreground App", group, app);
+        UpsertDisplayState(newStates, stateUpdates, "tp-hm.state.fps.source", $"{group} > FPS Source", group, source);
+    }
+
+    // Upsert helper shared by display and FPS states: create the state the
+    // first time an id is seen, then push an update only when its value changes.
     private static void UpsertDisplayState(List<TPStateDefinition> newStates, List<TPStateValue> stateUpdates,
         string id, string desc, string group, string value)
     {
@@ -1241,6 +1318,9 @@ class Program
 
         _hwService?.Dispose();
         _hwService = null;
+
+        _fpsService?.Dispose();
+        _fpsService = null;
 
         _tpClient?.Dispose();
         _tpClient = null;

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/EtwFpsProvider.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/EtwFpsProvider.cs
@@ -1,0 +1,152 @@
+using System.Collections.Concurrent;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Session;
+
+namespace TouchPortalHardwareMonitor.Services;
+
+/// <summary>
+/// In-process ETW FPS backend. Opens a real-time ETW session and counts DXGI /
+/// D3D9 present events per process; a process's FPS is the number of present
+/// events seen in the last sampling window. Requires elevation (ETW real-time
+/// sessions do). If it can't start (not elevated, blocked, trimmed away), it
+/// fails gracefully and callers fall back to RTSS.
+///
+/// NOTE: The present-event filter here is intentionally simple (event name
+/// contains "present"). It has NOT been validated against a broad set of real
+/// games/APIs and may need refinement (present model, Vulkan/GL coverage).
+/// </summary>
+public sealed class EtwFpsProvider : IDisposable
+{
+    private const string SessionName = "TPHM-FPS-Session";
+
+    private TraceEventSession? _session;
+    private Thread? _processThread;
+    private System.Threading.Timer? _sampleTimer;
+
+    private readonly ConcurrentDictionary<int, int> _counts = new();
+    private readonly ConcurrentDictionary<int, string> _names = new();
+    private volatile Dictionary<int, float> _fpsSnapshot = new();
+    private DateTime _lastSample = DateTime.UtcNow;
+
+    public string? LastError { get; private set; }
+    public bool Running { get; private set; }
+
+    public bool Start()
+    {
+        try
+        {
+            // A pre-existing session with this name (e.g. after a crash) blocks
+            // us; recreating with the same name stops the stale one.
+            _session = new TraceEventSession(SessionName) { StopOnDispose = true };
+            _session.EnableProvider("Microsoft-Windows-DXGI");
+            _session.EnableProvider("Microsoft-Windows-D3D9");
+            _session.Source.Dynamic.All += OnEvent;
+
+            _processThread = new Thread(() =>
+            {
+                try { _session.Source.Process(); }
+                catch (Exception ex) { LastError = ex.Message; }
+            })
+            {
+                IsBackground = true,
+                Name = "TPHM-FPS-ETW"
+            };
+            _processThread.Start();
+
+            _sampleTimer = new System.Threading.Timer(_ => Sample(), null, 1000, 1000);
+            Running = true;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            LastError = ex.Message;
+            Stop();
+            return false;
+        }
+    }
+
+    private void OnEvent(TraceEvent data)
+    {
+        if (data.ProcessID <= 0) return;
+
+        var name = data.EventName;
+        if (name != null && name.IndexOf("present", StringComparison.OrdinalIgnoreCase) >= 0)
+        {
+            _counts.AddOrUpdate(data.ProcessID, 1, (_, c) => c + 1);
+            if (!string.IsNullOrEmpty(data.ProcessName))
+            {
+                _names[data.ProcessID] = data.ProcessName;
+            }
+        }
+    }
+
+    private void Sample()
+    {
+        var now = DateTime.UtcNow;
+        var seconds = (now - _lastSample).TotalSeconds;
+        _lastSample = now;
+        if (seconds <= 0.001) seconds = 1;
+
+        var snapshot = new Dictionary<int, float>();
+        foreach (var pid in _counts.Keys.ToArray())
+        {
+            if (_counts.TryRemove(pid, out var count) && count > 0)
+            {
+                snapshot[pid] = (float)(count / seconds);
+            }
+        }
+        _fpsSnapshot = snapshot; // atomic reference swap
+    }
+
+    public FpsReading? GetFps(int foregroundPid)
+    {
+        var snapshot = _fpsSnapshot;
+
+        if (foregroundPid > 0 && snapshot.TryGetValue(foregroundPid, out var fg))
+        {
+            return new FpsReading(fg, NameFor(foregroundPid), "Built-in");
+        }
+
+        // Otherwise the busiest presenting process.
+        int bestPid = 0;
+        float bestFps = 0;
+        foreach (var kv in snapshot)
+        {
+            if (kv.Value > bestFps)
+            {
+                bestFps = kv.Value;
+                bestPid = kv.Key;
+            }
+        }
+
+        return bestPid != 0 ? new FpsReading(bestFps, NameFor(bestPid), "Built-in") : null;
+    }
+
+    private string NameFor(int pid)
+    {
+        if (_names.TryGetValue(pid, out var n) && !string.IsNullOrEmpty(n))
+        {
+            return n;
+        }
+        try
+        {
+            using var p = System.Diagnostics.Process.GetProcessById(pid);
+            return p.ProcessName;
+        }
+        catch
+        {
+            return pid.ToString();
+        }
+    }
+
+    private void Stop()
+    {
+        Running = false;
+        try { _sampleTimer?.Dispose(); } catch { }
+        _sampleTimer = null;
+        try { _session?.Dispose(); } catch { }
+        _session = null;
+    }
+
+    public void Dispose() => Stop();
+}

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/FpsService.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/FpsService.cs
@@ -1,0 +1,111 @@
+using System.Runtime.InteropServices;
+
+namespace TouchPortalHardwareMonitor.Services;
+
+public enum FpsMode
+{
+    Off,
+    Rtss,
+    Builtin,
+    Auto
+}
+
+/// <summary>FPS reading for the foreground app.</summary>
+public readonly record struct FpsReading(float Fps, string ProcessName, string Source);
+
+/// <summary>
+/// Orchestrates the FPS backends. Auto prefers RTSS (no elevation) and falls
+/// back to the in-process ETW backend. The ETW session is only started when a
+/// mode that needs it is selected.
+/// </summary>
+public sealed class FpsService : IDisposable
+{
+    private readonly RtssFpsProvider _rtss = new();
+    private EtwFpsProvider? _etw;
+    private FpsMode _mode = FpsMode.Auto;
+
+    public string? EtwError { get; private set; }
+    public bool EtwRunning => _etw?.Running == true;
+
+    public static FpsMode ParseMode(string? value)
+    {
+        return (value ?? "").Trim().ToLowerInvariant() switch
+        {
+            "off" => FpsMode.Off,
+            "rtss" => FpsMode.Rtss,
+            "built-in" or "builtin" => FpsMode.Builtin,
+            _ => FpsMode.Auto
+        };
+    }
+
+    /// <summary>(Re)configure for the selected mode, starting/stopping ETW as needed.</summary>
+    public void Configure(FpsMode mode)
+    {
+        _mode = mode;
+
+        bool needsEtw = mode is FpsMode.Builtin or FpsMode.Auto;
+        if (needsEtw && _etw == null)
+        {
+            _etw = new EtwFpsProvider();
+            if (!_etw.Start())
+            {
+                EtwError = _etw.LastError;
+            }
+        }
+        else if (!needsEtw && _etw != null)
+        {
+            _etw.Dispose();
+            _etw = null;
+        }
+    }
+
+    public FpsReading? GetForegroundFps()
+    {
+        if (_mode == FpsMode.Off) return null;
+
+        int pid = GetForegroundPid();
+
+        switch (_mode)
+        {
+            case FpsMode.Rtss:
+                return _rtss.GetFps(pid);
+
+            case FpsMode.Builtin:
+                return _etw?.GetFps(pid);
+
+            case FpsMode.Auto:
+                if (_rtss.IsAvailable())
+                {
+                    var r = _rtss.GetFps(pid);
+                    if (r != null) return r;
+                }
+                return _etw?.GetFps(pid);
+
+            default:
+                return null;
+        }
+    }
+
+    private static int GetForegroundPid()
+    {
+        try
+        {
+            var hwnd = GetForegroundWindow();
+            if (hwnd == IntPtr.Zero) return 0;
+            GetWindowThreadProcessId(hwnd, out uint pid);
+            return (int)pid;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+    public void Dispose() => _etw?.Dispose();
+}

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/RtssFpsProvider.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/RtssFpsProvider.cs
@@ -1,0 +1,114 @@
+using System.IO.MemoryMappedFiles;
+using System.Text;
+
+namespace TouchPortalHardwareMonitor.Services;
+
+/// <summary>
+/// Reads instantaneous FPS from RivaTuner Statistics Server (RTSS) shared
+/// memory ("RTSSSharedMemoryV2"). Works only while RTSS / MSI Afterburner is
+/// running, but needs no elevation, no kernel driver and no ETW session.
+/// </summary>
+public sealed class RtssFpsProvider
+{
+    private const string SharedMemoryName = "RTSSSharedMemoryV2";
+    private const uint Signature = 0x53535452; // 'RTSS'
+
+    // App-entry field offsets (RTSS_SHARED_MEMORY_APP_ENTRY, V2 layout).
+    private const int EntryProcessId = 0;
+    private const int EntryName = 4;      // char szName[MAX_PATH=260]
+    private const int EntryTime0 = 268;
+    private const int EntryTime1 = 272;
+    private const int EntryFrames = 276;
+
+    public bool IsAvailable()
+    {
+        if (!OperatingSystem.IsWindows()) return false;
+        try
+        {
+            using var mmf = MemoryMappedFile.OpenExisting(SharedMemoryName, MemoryMappedFileRights.Read);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// FPS for the given process id if RTSS is tracking it; otherwise the most
+    /// active tracked app; otherwise null.
+    /// </summary>
+    public FpsReading? GetFps(int foregroundPid)
+    {
+        if (!OperatingSystem.IsWindows()) return null;
+        try
+        {
+            using var mmf = MemoryMappedFile.OpenExisting(SharedMemoryName, MemoryMappedFileRights.Read);
+            using var acc = mmf.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+
+            if (acc.ReadUInt32(0) != Signature)
+            {
+                return null;
+            }
+
+            // Header: dwAppEntrySize@8, dwAppArrOffset@12, dwAppArrSize@16
+            uint entrySize = acc.ReadUInt32(8);
+            uint arrOffset = acc.ReadUInt32(12);
+            uint arrSize = acc.ReadUInt32(16);
+            if (entrySize == 0 || arrSize == 0)
+            {
+                return null;
+            }
+
+            FpsReading? best = null;
+            double bestFps = 0;
+
+            for (uint i = 0; i < arrSize; i++)
+            {
+                long entry = arrOffset + (long)i * entrySize;
+
+                uint pid = acc.ReadUInt32(entry + EntryProcessId);
+                if (pid == 0) continue;
+
+                uint time0 = acc.ReadUInt32(entry + EntryTime0);
+                uint time1 = acc.ReadUInt32(entry + EntryTime1);
+                uint frames = acc.ReadUInt32(entry + EntryFrames);
+                if (time1 <= time0) continue;
+
+                double fps = frames * 1000.0 / (time1 - time0);
+                if (fps <= 0) continue;
+
+                var name = ReadName(acc, entry + EntryName);
+
+                // Exact foreground match wins immediately.
+                if ((int)pid == foregroundPid)
+                {
+                    return new FpsReading((float)fps, name, "RTSS");
+                }
+
+                if (fps > bestFps)
+                {
+                    bestFps = fps;
+                    best = new FpsReading((float)fps, name, "RTSS");
+                }
+            }
+
+            return best;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string ReadName(MemoryMappedViewAccessor acc, long offset)
+    {
+        var bytes = new byte[260];
+        acc.ReadArray(offset, bytes, 0, bytes.Length);
+        int len = Array.IndexOf(bytes, (byte)0);
+        if (len < 0) len = bytes.Length;
+        var raw = Encoding.ASCII.GetString(bytes, 0, len);
+        int slash = raw.LastIndexOfAny(new[] { '\\', '/' });
+        return slash >= 0 ? raw[(slash + 1)..] : raw;
+    }
+}

--- a/csharp-plugin/TouchPortalHardwareMonitor/TouchPortalHardwareMonitor.csproj
+++ b/csharp-plugin/TouchPortalHardwareMonitor/TouchPortalHardwareMonitor.csproj
@@ -13,11 +13,19 @@
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AssemblyName>TouchPortalHardwareMonitor</AssemblyName>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.6" />
+    <!-- In-process ETW FPS backend. Not trim-friendly, so keep the whole
+         assembly; if the trimmer strips it the ETW provider fails at runtime
+         and Auto falls back to RTSS. -->
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <TrimmerRootAssembly Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp-plugin/TouchPortalHardwareMonitor/entry.tp
+++ b/csharp-plugin/TouchPortalHardwareMonitor/entry.tp
@@ -1,6 +1,6 @@
 {
   "sdk": 6,
-  "version": 2100,
+  "version": 2200,
   "name": "Touch Portal Hardware Monitor",
   "id": "TP_HM",
   "plugin_start_cmd": "\"%TP_PLUGIN_FOLDER%TouchPortalHardwareMonitor\\TouchPortalHardwareMonitor-Launcher.exe\"",
@@ -34,6 +34,12 @@
       "default":"No",
       "type":"text",
       "maxLength":3
+    },
+    {
+      "name":"FPS Source (Off/RTSS/Built-in/Auto)",
+      "default":"Auto",
+      "type":"text",
+      "maxLength":8
     }
   ],
   "categories": [

--- a/csharp-plugin/build.ps1
+++ b/csharp-plugin/build.ps1
@@ -8,7 +8,7 @@ $publishDir = "$projectDir\bin\Release\net10.0\win-x64\publish"
 $launcherPublishDir = "$launcherDir\bin\Release\net10.0\win-x64\publish"
 $installersDir = "$PSScriptRoot\Installers"
 $pluginName = "TouchPortalHardwareMonitor"
-$version = "2.1.0"
+$version = "2.2.0"
 
 Write-Host "Building Touch Portal Hardware Monitor C# Plugin v$version..." -ForegroundColor Cyan
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "touchportal-hardwaremonitor",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Touch Portal plugin to read data from LibreHardwareMonitor",
   "main": "src/index.js",
   "bin": "src/index.js",


### PR DESCRIPTION
**Stacked on #24** (base is `feat/display-fps-states`; GitHub will retarget to `main` once #24 merges). This is the "rendered FPS" half of the FPS request.

Adds foreground-app FPS as Touch Portal states under an **FPS** category, sourced independently of LibreHardwareMonitor, with a user-selectable backend.

## Setting
`FPS Source (Off/RTSS/Built-in/Auto)` — default **Auto**. Applies live (no restart).

## Backends
- **RTSS** (`RtssFpsProvider`) — reads RivaTuner Statistics Server shared memory (`RTSSSharedMemoryV2`). No elevation, no driver; works only while RTSS / MSI Afterburner is running.
- **Built-in** (`EtwFpsProvider`) — in-process ETW session counting DXGI/D3D9 present events per process (TraceEvent). Needs elevation (which the plugin already has); fails gracefully if it can't start.
- **Auto** (`FpsService`) — prefer RTSS if running, else fall back to Built-in. ETW session only started for Built-in/Auto.

## States (parent group "FPS")
- `tp-hm.state.fps.value` (+ `.unit` = `FPS`)
- `tp-hm.state.fps.process` — foreground app
- `tp-hm.state.fps.source` — `RTSS` / `Built-in`

## Testing
- `dotnet build -c Release`: 0 warnings, 0 errors.
- **Trimming risk mitigated:** TraceEvent kept whole via `TrimmerRootAssembly`; verified the **trimmed single-file** publish loads and starts it — non-elevated it fails with a clean "Access Denied (Administrator rights required to start ETW)" rather than a trim/TypeLoad crash, and Auto falls through to "(none)".
- New `--fps` CLI probe (`TouchPortalHardwareMonitor.exe --fps`) samples ~10s.
- Packaged `TouchPortalHardwareMonitor-Windows-2.2.0.tpp`.

## ⚠️ Not yet validated
The ETW present-event filter (event name contains "present") is a **first cut** and has **not** been tested against real games across present models / APIs (DX12, Vulkan, GL, fullscreen vs borderless). It needs an **elevated, in-game** run — use `--fps` to check. The RTSS path and graceful fallback are verified. Expect to iterate on the ETW event selection.

Same caveat as the LHM driver: the ETW backend needs admin + an ETW session, so Memory Integrity / antivirus could interfere — Auto's RTSS preference sidesteps that when RTSS is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)