### PR TITLE
fix(csharp): PresentMon FPS backend + fix ETW counter (2.2.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,7 @@ Installers/
 
 # Claude Code local settings
 .claude/settings.local.json
+
+# Bundled third-party tools downloaded at build time (not committed)
+csharp-plugin/tools/
+PresentMon.exe

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Turn your PC's live hardware sensors — **CPU, GPU, RAM, storage, network, moth
   - `….unit` — always available (°C/°F, %, W, MHz, RPM, GB, …)
   - `….min` / `….max` — lowest/highest observed value
 - 🖥️ **Display states** — refresh rate (Hz), resolution, name and primary flag per monitor. *No driver, no elevation.*
-- 🎮 **FPS states** — foreground-app frame rate, with a selectable source (**RTSS / in-process ETW / Auto**).
+- 🎮 **FPS states** — foreground-app frame rate, with a selectable source (**RTSS / PresentMon / in-process ETW / Auto**).
 - ⏱️ **Live settings** — changing the capture interval or FPS source applies immediately, no restart.
 - 🔢 **Stable hardware numbering** — persistent per-device indexes saved to `%AppData%\TouchPortalHardwareMonitor`, so `CPU1`, `GPU1`, `Network1`, … keep pointing at the same device across restarts and reinstalls.
 - 🧹 **Cleaner device list** — Windows network filter drivers and virtual/inactive adapters are filtered out; only hardware that reports sensors is published.
@@ -58,7 +58,7 @@ tp-hm.state.{TYPE}{index}.{SensorType}.{name}.min / .max
 |---|---|
 | `tp-hm.state.fps.value` (+ `.unit`) | `144` / `FPS` |
 | `tp-hm.state.fps.process` | `game.exe` |
-| `tp-hm.state.fps.source` | `RTSS` / `Built-in` |
+| `tp-hm.state.fps.source` | `RTSS` / `PresentMon` / `Built-in` |
 
 **Diagnostics state** (group **TP Hardware Monitor**):
 
@@ -116,7 +116,7 @@ The plugin launches elevated so it can read all sensors. Accept the Windows UAC 
 | Temperature Unit (C/F) | `C` | `C` / `F` | |
 | Normalize Throughput (B/s, KB/s, MB/s, GB/s) | `No` | `No` / `Yes` | Scales network throughput to a friendlier unit; adds a `.unit` state. |
 | Normalize Data (MB, GB) | `No` | `No` / `Yes` | Scales SmallData (e.g. VRAM) to a friendlier unit; adds a `.unit` state. |
-| **FPS Source (Off/RTSS/Built-in/Auto)** | `Auto` | `Off` / `RTSS` / `Built-in` / `Auto` | **Applies live.** `Auto` = RTSS if running, else in-process ETW. |
+| **FPS Source (Off/RTSS/PresentMon/Built-in/Auto)** | `Auto` | `Off` / `RTSS` / `PresentMon` / `Built-in` / `Auto` | **Applies live.** `Auto` = RTSS if running → PresentMon → in-process ETW. `PresentMon` and `Built-in` need Admin; `Built-in` is approximate. |
 
 > [!NOTE]
 > The v1.x **"Hardware Monitor To Use"** setting is gone — LibreHardwareMonitor is embedded, so there's no external source to choose.
@@ -178,6 +178,8 @@ The **`tp-hm.state.plugin.sensor_status`** state summarizes this in plain langua
 ```
 
 This publishes the self-contained plugin + launcher and packages them into `csharp-plugin\Installers\TouchPortalHardwareMonitor-Windows-<version>.tpp`, ready to import.
+
+On first run the script also **downloads [Intel PresentMon](https://github.com/GameTechDev/PresentMon) 1.10.0** (MIT) into `csharp-plugin\tools\` (gitignored, not committed) and bundles it for the accurate FPS backend. If the download is skipped/unavailable, the plugin still builds — only the `PresentMon` FPS source is unavailable.
 
 ---
 

--- a/csharp-plugin/Launcher/Launcher.csproj
+++ b/csharp-plugin/Launcher/Launcher.csproj
@@ -11,7 +11,7 @@
     <PublishTrimmed>true</PublishTrimmed>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <AssemblyName>TouchPortalHardwareMonitor-Launcher</AssemblyName>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
   </PropertyGroup>
 
 </Project>

--- a/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
@@ -96,7 +96,7 @@ class Program
             var dump = new DiagnosticDump
             {
                 Timestamp = DateTime.Now.ToString("o"),
-                PluginVersion = "2.2.0",
+                PluginVersion = "2.2.1",
                 IsElevated = _isElevated,
                 SensorAccess = DetectSensorAccessStatus(rawSensorData).Message,
                 Settings = new DiagnosticSettings
@@ -443,7 +443,7 @@ class Program
             return;
         }
 
-        Log("Touch Portal Hardware Monitor v2.2.0 starting...");
+        Log("Touch Portal Hardware Monitor v2.2.1 starting...");
 
         // Initialize log level from file (before anything else)
         InitializeLogLevel();
@@ -482,6 +482,10 @@ class Program
             // Initialize FPS reporting (Auto by default; a setting may change it)
             _fpsService = new FpsService();
             _fpsService.Configure(_fpsMode);
+            if (_fpsService.PresentMonError != null)
+            {
+                Log($"FPS: PresentMon backend unavailable ({_fpsService.PresentMonError}).");
+            }
             if (_fpsService.EtwError != null)
             {
                 Log($"FPS: in-process ETW backend unavailable ({_fpsService.EtwError}). RTSS will be used if it is running.");
@@ -565,7 +569,7 @@ class Program
                     case "Normalize Data (MB, GB)":
                         _normalizeData = kvp.Value;
                         break;
-                    case "FPS Source (Off/RTSS/Built-in/Auto)":
+                    case "FPS Source (Off/RTSS/PresentMon/Built-in/Auto)":
                         var newMode = FpsService.ParseMode(kvp.Value);
                         if (newMode != _fpsMode)
                         {

--- a/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Net.NetworkInformation;
 using System.Security.Principal;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using TouchPortalHardwareMonitor.Models;
@@ -1128,11 +1130,34 @@ class Program
         { "Humidity", "Humidity" }
     };
 
+    // Build the sensor-name portion of a Touch Portal state ID. TP state IDs
+    // must be plain ASCII identifiers, but LibreHardwareMonitor names can carry
+    // non-ASCII (e.g. a French cooler's "T° Eau 360" / "Débitmetre"), which TP
+    // rejects. Transliterate accents to ASCII and drop remaining non-ASCII, but
+    // keep every ASCII character exactly as before so existing state IDs are
+    // unchanged (no broken buttons). The original name is kept in the state
+    // description elsewhere.
+    private static string SanitizeStateSegment(string name)
+    {
+        var lowered = name.ToLowerInvariant().Replace(" ", ".").Replace("#", "");
+        var decomposed = lowered.Normalize(NormalizationForm.FormD);
+
+        var sb = new StringBuilder(decomposed.Length);
+        foreach (var ch in decomposed)
+        {
+            // Drop combining accent marks left by decomposition (é -> e).
+            if (CharUnicodeInfo.GetUnicodeCategory(ch) == UnicodeCategory.NonSpacingMark) continue;
+            // Keep ASCII as-is; drop non-ASCII symbols (e.g. the degree sign).
+            if (ch <= '\x7F') sb.Append(ch);
+        }
+        return sb.ToString();
+    }
+
     private static SensorStateInfo BuildSensorStateId(string hardwareKey, SensorItem sensor)
     {
         var hw = _hardware[hardwareKey];
         var sensorType = sensor.SensorType;
-        var sensorName = sensor.Name.ToLower().Replace(" ", ".").Replace("#", "");
+        var sensorName = SanitizeStateSegment(sensor.Name);
         var indexNum = hw.Index > 0 ? hw.Index.ToString() : "";
 
         // State ID remains unchanged for backwards compatibility

--- a/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
@@ -429,6 +429,7 @@ class Program
         {
             _isElevated = IsProcessElevated();
             Console.WriteLine($"Elevated: {_isElevated}");
+            FpsService.DebugLog = Console.WriteLine;   // verbose backend logging for the probe
             using var probe = new FpsService();
             probe.Configure(FpsMode.Auto);
             if (probe.EtwError != null) Console.WriteLine($"ETW backend error: {probe.EtwError}");
@@ -481,6 +482,7 @@ class Program
 
             // Initialize FPS reporting (Auto by default; a setting may change it)
             _fpsService = new FpsService();
+            FpsService.DebugLog = LogDebug;   // DEBUG-gated backend logging
             _fpsService.Configure(_fpsMode);
             if (_fpsService.PresentMonError != null)
             {
@@ -1271,6 +1273,13 @@ class Program
         {
             LogDebug($"[FPS] read failed: {ex.Message}");
             return;
+        }
+
+        if (_debugLogging)
+        {
+            LogDebug(reading.HasValue
+                ? $"[FPS] value={reading.Value.Fps:F1} source={reading.Value.Source} app={reading.Value.ProcessName}"
+                : $"[FPS] no reading (mode={_fpsMode}, rtssAvail={_fpsService.RtssAvailable}, pmRunning={_fpsService.PresentMonRunning}, etwRunning={_fpsService.EtwRunning})");
         }
 
         const string group = "FPS";

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/EtwFpsProvider.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/EtwFpsProvider.cs
@@ -11,9 +11,12 @@ namespace TouchPortalHardwareMonitor.Services;
 /// sessions do). If it can't start (not elevated, blocked, trimmed away), it
 /// fails gracefully and callers fall back to RTSS.
 ///
-/// NOTE: The present-event filter here is intentionally simple (event name
-/// contains "present"). It has NOT been validated against a broad set of real
-/// games/APIs and may need refinement (present model, Vulkan/GL coverage).
+/// NOTE: This counts DXGI/D3D9 *present calls* (one per PresentStart), which
+/// approximates FPS but is not frame-accurate: uncapped apps present far more
+/// often than they display, so this over-reads when a game is uncapped, and it
+/// does not cover every present model / API the way PresentMon does. Treat it
+/// as an approximate fallback; prefer RTSS or the PresentMon backend for
+/// accurate displayed FPS.
 /// </summary>
 public sealed class EtwFpsProvider : IDisposable
 {
@@ -38,8 +41,10 @@ public sealed class EtwFpsProvider : IDisposable
             // A pre-existing session with this name (e.g. after a crash) blocks
             // us; recreating with the same name stops the stale one.
             _session = new TraceEventSession(SessionName) { StopOnDispose = true };
-            _session.EnableProvider("Microsoft-Windows-DXGI");
-            _session.EnableProvider("Microsoft-Windows-D3D9");
+            // Informational level (not full Verbose) keeps the volume to present
+            // events rather than every DXGI/D3D9 diagnostic event.
+            _session.EnableProvider("Microsoft-Windows-DXGI", TraceEventLevel.Informational);
+            _session.EnableProvider("Microsoft-Windows-D3D9", TraceEventLevel.Informational);
             _session.Source.Dynamic.All += OnEvent;
 
             _processThread = new Thread(() =>
@@ -69,14 +74,19 @@ public sealed class EtwFpsProvider : IDisposable
     {
         if (data.ProcessID <= 0) return;
 
+        // Count exactly ONE event per present: the *start* of a DXGI/D3D9
+        // present. The previous "name contains 'present'" filter also matched
+        // PresentStop (so ~2x per frame) plus other present-tagged/overlay
+        // events, which inflated and destabilized the rate.
+        if (data.Opcode != TraceEventOpcode.Start) return;
+
         var name = data.EventName;
-        if (name != null && name.IndexOf("present", StringComparison.OrdinalIgnoreCase) >= 0)
+        if (name == null || name.IndexOf("present", StringComparison.OrdinalIgnoreCase) < 0) return;
+
+        _counts.AddOrUpdate(data.ProcessID, 1, (_, c) => c + 1);
+        if (!string.IsNullOrEmpty(data.ProcessName))
         {
-            _counts.AddOrUpdate(data.ProcessID, 1, (_, c) => c + 1);
-            if (!string.IsNullOrEmpty(data.ProcessName))
-            {
-                _names[data.ProcessID] = data.ProcessName;
-            }
+            _names[data.ProcessID] = data.ProcessName;
         }
     }
 

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/EtwFpsProvider.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/EtwFpsProvider.cs
@@ -60,11 +60,13 @@ public sealed class EtwFpsProvider : IDisposable
 
             _sampleTimer = new System.Threading.Timer(_ => Sample(), null, 1000, 1000);
             Running = true;
+            FpsService.Dbg($"[FPS] ETW session '{SessionName}' started (DXGI/D3D9 present events).");
             return true;
         }
         catch (Exception ex)
         {
             LastError = ex.Message;
+            FpsService.Dbg($"[FPS] ETW session failed to start: {ex.Message}");
             Stop();
             return false;
         }

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/EtwFpsProvider.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/EtwFpsProvider.cs
@@ -85,6 +85,9 @@ public sealed class EtwFpsProvider : IDisposable
         var name = data.EventName;
         if (name == null || name.IndexOf("present", StringComparison.OrdinalIgnoreCase) < 0) return;
 
+        // Skip the desktop compositor etc. - not a meaningful "game" FPS.
+        if (FpsService.IsExcludedApp(data.ProcessName)) return;
+
         _counts.AddOrUpdate(data.ProcessID, 1, (_, c) => c + 1);
         if (!string.IsNullOrEmpty(data.ProcessName))
         {
@@ -124,11 +127,10 @@ public sealed class EtwFpsProvider : IDisposable
         float bestFps = 0;
         foreach (var kv in snapshot)
         {
-            if (kv.Value > bestFps)
-            {
-                bestFps = kv.Value;
-                bestPid = kv.Key;
-            }
+            if (kv.Value <= bestFps) continue;
+            if (FpsService.IsExcludedApp(NameFor(kv.Key))) continue;
+            bestFps = kv.Value;
+            bestPid = kv.Key;
         }
 
         return bestPid != 0 ? new FpsReading(bestFps, NameFor(bestPid), "Built-in") : null;

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/FpsService.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/FpsService.cs
@@ -7,6 +7,7 @@ public enum FpsMode
     Off,
     Rtss,
     Builtin,
+    PresentMon,
     Auto
 }
 
@@ -14,18 +15,21 @@ public enum FpsMode
 public readonly record struct FpsReading(float Fps, string ProcessName, string Source);
 
 /// <summary>
-/// Orchestrates the FPS backends. Auto prefers RTSS (no elevation) and falls
-/// back to the in-process ETW backend. The ETW session is only started when a
-/// mode that needs it is selected.
+/// Orchestrates the FPS backends. Auto prefers RTSS (accurate, no elevation),
+/// then PresentMon (accurate, bundled exe), then the in-process ETW counter
+/// (approximate). Only the backend(s) needed for the selected mode are started.
 /// </summary>
 public sealed class FpsService : IDisposable
 {
     private readonly RtssFpsProvider _rtss = new();
     private EtwFpsProvider? _etw;
+    private PresentMonFpsProvider? _pm;
     private FpsMode _mode = FpsMode.Auto;
 
     public string? EtwError { get; private set; }
+    public string? PresentMonError { get; private set; }
     public bool EtwRunning => _etw?.Running == true;
+    public bool PresentMonRunning => _pm?.Running == true;
 
     public static FpsMode ParseMode(string? value)
     {
@@ -34,28 +38,48 @@ public sealed class FpsService : IDisposable
             "off" => FpsMode.Off,
             "rtss" => FpsMode.Rtss,
             "built-in" or "builtin" => FpsMode.Builtin,
+            "presentmon" or "present-mon" => FpsMode.PresentMon,
             _ => FpsMode.Auto
         };
     }
 
-    /// <summary>(Re)configure for the selected mode, starting/stopping ETW as needed.</summary>
+    /// <summary>(Re)configure for the selected mode, starting/stopping backends as needed.</summary>
     public void Configure(FpsMode mode)
     {
         _mode = mode;
+        switch (mode)
+        {
+            case FpsMode.Off:
+            case FpsMode.Rtss:
+                StopPresentMon();
+                StopEtw();
+                break;
 
-        bool needsEtw = mode is FpsMode.Builtin or FpsMode.Auto;
-        if (needsEtw && _etw == null)
-        {
-            _etw = new EtwFpsProvider();
-            if (!_etw.Start())
-            {
-                EtwError = _etw.LastError;
-            }
-        }
-        else if (!needsEtw && _etw != null)
-        {
-            _etw.Dispose();
-            _etw = null;
+            case FpsMode.PresentMon:
+                StopEtw();
+                EnsurePresentMon();
+                break;
+
+            case FpsMode.Builtin:
+                StopPresentMon();
+                EnsureEtw();
+                break;
+
+            case FpsMode.Auto:
+                // Prefer PresentMon as the self-contained backend; fall back to
+                // the ETW counter only if PresentMon can't run. (RTSS needs no
+                // backend started - it's checked at read time.)
+                EnsurePresentMon();
+                if (_pm?.Running == true)
+                {
+                    StopEtw();
+                }
+                else
+                {
+                    StopPresentMon();
+                    EnsureEtw();
+                }
+                break;
         }
     }
 
@@ -70,6 +94,9 @@ public sealed class FpsService : IDisposable
             case FpsMode.Rtss:
                 return _rtss.GetFps(pid);
 
+            case FpsMode.PresentMon:
+                return _pm?.GetFps(pid);
+
             case FpsMode.Builtin:
                 return _etw?.GetFps(pid);
 
@@ -79,11 +106,52 @@ public sealed class FpsService : IDisposable
                     var r = _rtss.GetFps(pid);
                     if (r != null) return r;
                 }
+                if (_pm?.Running == true)
+                {
+                    var r = _pm.GetFps(pid);
+                    if (r != null) return r;
+                }
                 return _etw?.GetFps(pid);
 
             default:
                 return null;
         }
+    }
+
+    private void EnsureEtw()
+    {
+        if (_etw != null) return;
+        _etw = new EtwFpsProvider();
+        if (!_etw.Start())
+        {
+            EtwError = _etw.LastError;
+            _etw.Dispose();
+            _etw = null;
+        }
+    }
+
+    private void StopEtw()
+    {
+        _etw?.Dispose();
+        _etw = null;
+    }
+
+    private void EnsurePresentMon()
+    {
+        if (_pm != null) return;
+        _pm = new PresentMonFpsProvider(PresentMonFpsProvider.DefaultExePath());
+        if (!_pm.Start())
+        {
+            PresentMonError = _pm.LastError;
+            _pm.Dispose();
+            _pm = null;
+        }
+    }
+
+    private void StopPresentMon()
+    {
+        _pm?.Dispose();
+        _pm = null;
     }
 
     private static int GetForegroundPid()
@@ -107,5 +175,9 @@ public sealed class FpsService : IDisposable
     [DllImport("user32.dll")]
     private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
-    public void Dispose() => _etw?.Dispose();
+    public void Dispose()
+    {
+        StopPresentMon();
+        StopEtw();
+    }
 }

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/FpsService.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/FpsService.cs
@@ -41,6 +41,24 @@ public sealed class FpsService : IDisposable
 
     internal static void Dbg(string message) => DebugLog?.Invoke(message);
 
+    // Processes that present frames but aren't a user-facing "game" - reporting
+    // their FPS is misleading (e.g. dwm.exe is the desktop compositor, which
+    // presents at the refresh rate whenever you're on the desktop).
+    private static readonly HashSet<string> ExcludedApps = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "dwm.exe",
+        "dwm"
+    };
+
+    internal static bool IsExcludedApp(string? name)
+    {
+        if (string.IsNullOrEmpty(name)) return false;
+        var n = name;
+        int slash = n.LastIndexOfAny(new[] { '\\', '/' });
+        if (slash >= 0) n = n[(slash + 1)..];
+        return ExcludedApps.Contains(n);
+    }
+
     public static FpsMode ParseMode(string? value)
     {
         return (value ?? "").Trim().ToLowerInvariant() switch

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/FpsService.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/FpsService.cs
@@ -30,6 +30,16 @@ public sealed class FpsService : IDisposable
     public string? PresentMonError { get; private set; }
     public bool EtwRunning => _etw?.Running == true;
     public bool PresentMonRunning => _pm?.Running == true;
+    public bool RtssAvailable => _rtss.IsAvailable();
+    public FpsMode Mode => _mode;
+
+    /// <summary>
+    /// Optional DEBUG sink shared by the FPS backends. Program wires this to
+    /// LogDebug (only active when loglevel.txt = DEBUG).
+    /// </summary>
+    public static Action<string>? DebugLog { get; set; }
+
+    internal static void Dbg(string message) => DebugLog?.Invoke(message);
 
     public static FpsMode ParseMode(string? value)
     {
@@ -81,6 +91,10 @@ public sealed class FpsService : IDisposable
                 }
                 break;
         }
+
+        Dbg($"[FPS] mode={_mode} | RTSS avail={_rtss.IsAvailable()} | " +
+            $"PresentMon={(_pm?.Running == true ? "running" : "off")}{(PresentMonError != null ? $" (err: {PresentMonError})" : "")} | " +
+            $"ETW={(_etw?.Running == true ? "running" : "off")}{(EtwError != null ? $" (err: {EtwError})" : "")}");
     }
 
     public FpsReading? GetForegroundFps()

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/HardwareMonitorService.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/HardwareMonitorService.cs
@@ -25,6 +25,14 @@ public class HardwareMonitorService : IDisposable
         _computer.Open();
     }
 
+    // LibreHardwareMonitor sometimes returns hardware/sensor names with embedded
+    // control characters (e.g. NUL or form-feed in garbled DIMM part numbers).
+    // Strip them so they don't corrupt state IDs, logs, or Touch Portal display.
+    private static string Clean(string? value)
+        => string.IsNullOrEmpty(value)
+            ? string.Empty
+            : new string(value.Where(c => !char.IsControl(c)).ToArray()).Trim();
+
     public List<HardwareItem> GetHardware()
     {
         var result = new List<HardwareItem>();
@@ -39,7 +47,7 @@ public class HardwareMonitorService : IDisposable
             result.Add(new HardwareItem
             {
                 Identifier = hardware.Identifier.ToString(),
-                Name = hardware.Name,
+                Name = Clean(hardware.Name),
                 HardwareType = hardware.HardwareType.ToString()
             });
 
@@ -83,7 +91,7 @@ public class HardwareMonitorService : IDisposable
                 {
                     Parent = hardware.Identifier.ToString(),
                     Identifier = sensor.Identifier.ToString(),
-                    Name = sensor.Name,
+                    Name = Clean(sensor.Name),
                     SensorType = sensor.SensorType.ToString(),
                     Value = hasValue ? sensor.Value!.Value : float.NaN,
                     ValuePresent = hasValue,

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/PresentMonFpsProvider.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/PresentMonFpsProvider.cs
@@ -1,0 +1,179 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace TouchPortalHardwareMonitor.Services;
+
+/// <summary>
+/// FPS via Intel <b>PresentMon</b> (bundled next to the plugin as
+/// <c>PresentMon.exe</c>). Runs PresentMon as a child process capturing all
+/// processes and parses its CSV stream, computing per-process FPS from
+/// <c>msBetweenPresents</c>. PresentMon is the reference implementation for
+/// present timing, so this is far more accurate than the in-process ETW
+/// counter. Requires elevation (PresentMon uses ETW) — the plugin already runs
+/// elevated. If <c>PresentMon.exe</c> isn't present it reports unavailable.
+/// </summary>
+public sealed class PresentMonFpsProvider : IDisposable
+{
+    private sealed class Entry
+    {
+        public double EmaFrametimeMs;
+        public long LastTick;
+        public string Name = "";
+    }
+
+    private const long StaleMs = 2000;
+
+    private readonly string _exePath;
+    private readonly ConcurrentDictionary<int, Entry> _entries = new();
+
+    private Process? _proc;
+    private int _pidCol = -1;
+    private int _msCol = -1;
+    private int _appCol = -1;
+    private volatile bool _headerParsed;
+
+    public string? LastError { get; private set; }
+    public bool Running { get; private set; }
+
+    public PresentMonFpsProvider(string exePath) => _exePath = exePath;
+
+    public static string DefaultExePath() => Path.Combine(AppContext.BaseDirectory, "PresentMon.exe");
+
+    public bool Start()
+    {
+        if (!File.Exists(_exePath))
+        {
+            LastError = $"PresentMon.exe not found at {_exePath}";
+            return false;
+        }
+
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = _exePath,
+                // Stream CSV to stdout, capture all processes, suppress the
+                // interactive console output, and reclaim any stale session.
+                Arguments = "-output_stdout -stop_existing_session -no_top",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = Path.GetDirectoryName(_exePath) ?? AppContext.BaseDirectory
+            };
+
+            _proc = new Process { StartInfo = psi, EnableRaisingEvents = true };
+            _proc.OutputDataReceived += OnOutput;
+            _proc.ErrorDataReceived += (_, e) => { if (!string.IsNullOrWhiteSpace(e.Data)) LastError = e.Data; };
+            _proc.Exited += (_, _) => Running = false;
+
+            _proc.Start();
+            _proc.BeginOutputReadLine();
+            _proc.BeginErrorReadLine();
+            Running = true;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            LastError = ex.Message;
+            Stop();
+            return false;
+        }
+    }
+
+    private void OnOutput(object sender, DataReceivedEventArgs e)
+    {
+        var line = e.Data;
+        if (string.IsNullOrEmpty(line)) return;
+
+        if (!_headerParsed)
+        {
+            if (line.IndexOf("ProcessID", StringComparison.OrdinalIgnoreCase) < 0) return;
+
+            var cols = line.Split(',');
+            for (int i = 0; i < cols.Length; i++)
+            {
+                var c = cols[i].Trim();
+                if (c.Equals("ProcessID", StringComparison.OrdinalIgnoreCase)) _pidCol = i;
+                else if (c.Equals("msBetweenPresents", StringComparison.OrdinalIgnoreCase)) _msCol = i;
+                else if (c.Equals("Application", StringComparison.OrdinalIgnoreCase)) _appCol = i;
+            }
+            _headerParsed = _pidCol >= 0 && _msCol >= 0;
+            return;
+        }
+
+        var f = line.Split(',');
+        if (f.Length <= _pidCol || f.Length <= _msCol) return;
+        if (!int.TryParse(f[_pidCol], out var pid)) return;
+        if (!double.TryParse(f[_msCol], NumberStyles.Float, CultureInfo.InvariantCulture, out var ms)) return;
+        if (ms <= 0 || double.IsNaN(ms) || double.IsInfinity(ms)) return;
+
+        var entry = _entries.GetOrAdd(pid, _ => new Entry());
+        // Smooth frametime so the reported FPS isn't jittery frame-to-frame.
+        entry.EmaFrametimeMs = entry.EmaFrametimeMs <= 0 ? ms : (entry.EmaFrametimeMs * 0.8) + (ms * 0.2);
+        entry.LastTick = Environment.TickCount64;
+        if (_appCol >= 0 && f.Length > _appCol && !string.IsNullOrWhiteSpace(f[_appCol]))
+        {
+            entry.Name = f[_appCol];
+        }
+    }
+
+    public FpsReading? GetFps(int foregroundPid)
+    {
+        long now = Environment.TickCount64;
+
+        if (foregroundPid > 0
+            && _entries.TryGetValue(foregroundPid, out var fe)
+            && now - fe.LastTick <= StaleMs
+            && fe.EmaFrametimeMs > 0)
+        {
+            return new FpsReading((float)(1000.0 / fe.EmaFrametimeMs), NameOf(foregroundPid, fe), "PresentMon");
+        }
+
+        // Otherwise the busiest fresh presenter.
+        Entry? best = null;
+        int bestPid = 0;
+        double bestFps = 0;
+        foreach (var kv in _entries)
+        {
+            if (now - kv.Value.LastTick > StaleMs || kv.Value.EmaFrametimeMs <= 0) continue;
+            var fps = 1000.0 / kv.Value.EmaFrametimeMs;
+            if (fps > bestFps)
+            {
+                bestFps = fps;
+                best = kv.Value;
+                bestPid = kv.Key;
+            }
+        }
+
+        return best != null ? new FpsReading((float)bestFps, NameOf(bestPid, best), "PresentMon") : null;
+    }
+
+    private static string NameOf(int pid, Entry e)
+    {
+        if (!string.IsNullOrEmpty(e.Name) && !e.Name.Equals("<error>", StringComparison.OrdinalIgnoreCase))
+        {
+            return e.Name;
+        }
+        try
+        {
+            using var p = Process.GetProcessById(pid);
+            return p.ProcessName;
+        }
+        catch
+        {
+            return pid.ToString();
+        }
+    }
+
+    private void Stop()
+    {
+        Running = false;
+        try { if (_proc is { HasExited: false }) _proc.Kill(true); } catch { }
+        try { _proc?.Dispose(); } catch { }
+        _proc = null;
+    }
+
+    public void Dispose() => Stop();
+}

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/PresentMonFpsProvider.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/PresentMonFpsProvider.cs
@@ -99,11 +99,13 @@ public sealed class PresentMonFpsProvider : IDisposable
             _proc.BeginOutputReadLine();
             _proc.BeginErrorReadLine();
             Running = true;
+            FpsService.Dbg($"[FPS] PresentMon started (pid {_proc.Id}) from {_runPath}");
             return true;
         }
         catch (Exception ex)
         {
             LastError = ex.Message;
+            FpsService.Dbg($"[FPS] PresentMon failed to start: {ex.Message}");
             Stop();
             return false;
         }
@@ -127,6 +129,9 @@ public sealed class PresentMonFpsProvider : IDisposable
                 else if (c.Equals("Application", StringComparison.OrdinalIgnoreCase)) _appCol = i;
             }
             _headerParsed = _pidCol >= 0 && _msCol >= 0;
+            FpsService.Dbg(_headerParsed
+                ? $"[FPS] PresentMon CSV header parsed (pidCol={_pidCol}, msCol={_msCol}, appCol={_appCol})"
+                : "[FPS] PresentMon CSV header missing ProcessID/msBetweenPresents columns");
             return;
         }
 

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/PresentMonFpsProvider.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/PresentMonFpsProvider.cs
@@ -25,7 +25,8 @@ public sealed class PresentMonFpsProvider : IDisposable
 
     private const long StaleMs = 2000;
 
-    private readonly string _exePath;
+    private readonly string _bundledPath; // shipped in the plugin folder; never executed directly
+    private readonly string _runPath;     // working copy (outside the plugin folder) we actually launch
     private readonly ConcurrentDictionary<int, Entry> _entries = new();
 
     private Process? _proc;
@@ -38,28 +39,39 @@ public sealed class PresentMonFpsProvider : IDisposable
     public string? LastError { get; private set; }
     public bool Running { get; private set; }
 
-    public PresentMonFpsProvider(string exePath) => _exePath = exePath;
+    public PresentMonFpsProvider(string bundledExePath)
+    {
+        _bundledPath = bundledExePath;
+        var workingDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "TouchPortalHardwareMonitor");
+        _runPath = Path.Combine(workingDir, "PresentMon.exe");
+    }
 
     public static string DefaultExePath() => Path.Combine(AppContext.BaseDirectory, "PresentMon.exe");
 
     public bool Start()
     {
-        if (!File.Exists(_exePath))
+        if (!File.Exists(_bundledPath))
         {
-            LastError = $"PresentMon.exe not found at {_exePath}";
+            LastError = $"PresentMon.exe not found at {_bundledPath}";
             return false;
         }
 
-        // Clean up any copy of our bundled PresentMon left running by a previous
-        // plugin instance (e.g. after a hard kill), so it doesn't hold the ETW
-        // session or a file lock.
-        KillOrphans();
+        // Run PresentMon from a working copy OUTSIDE the plugin folder. Touch
+        // Portal overwrites the plugin folder on re-import and fails if the
+        // bundled PresentMon.exe is locked by a running process; keeping the
+        // executing copy elsewhere means the plugin-folder file is never locked.
+        if (!PrepareWorkingCopy())
+        {
+            return false;
+        }
 
         try
         {
             var psi = new ProcessStartInfo
             {
-                FileName = _exePath,
+                FileName = _runPath,
                 // Stream CSV to stdout, capture all processes, suppress the
                 // interactive console output, and reclaim any stale session.
                 Arguments = "-output_stdout -stop_existing_session -no_top",
@@ -67,7 +79,7 @@ public sealed class PresentMonFpsProvider : IDisposable
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
-                WorkingDirectory = Path.GetDirectoryName(_exePath) ?? AppContext.BaseDirectory
+                WorkingDirectory = Path.GetDirectoryName(_runPath) ?? AppContext.BaseDirectory
             };
 
             _proc = new Process { StartInfo = psi, EnableRaisingEvents = true };
@@ -199,13 +211,45 @@ public sealed class PresentMonFpsProvider : IDisposable
 
     public void Dispose() => Stop();
 
-    // Kill any leftover instance of *our* bundled PresentMon.exe (matched by
-    // full path, so a user's own PresentMon elsewhere is left alone).
+    // Refresh the working copy we launch from, killing any leftover copy first.
+    private bool PrepareWorkingCopy()
+    {
+        KillOrphans();
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_runPath)!);
+            for (int attempt = 0; attempt < 5; attempt++)
+            {
+                try
+                {
+                    File.Copy(_bundledPath, _runPath, overwrite: true);
+                    return true;
+                }
+                catch (IOException) when (attempt < 4)
+                {
+                    // A dying orphan may still hold the file briefly.
+                    Thread.Sleep(200);
+                }
+            }
+            // If we couldn't refresh it but a usable copy already exists, run that.
+            if (File.Exists(_runPath)) return true;
+            LastError = $"Could not prepare PresentMon working copy at {_runPath}";
+            return false;
+        }
+        catch (Exception ex)
+        {
+            LastError = ex.Message;
+            return false;
+        }
+    }
+
+    // Kill any leftover instance of *our* working-copy PresentMon.exe (matched
+    // by full path, so a user's own PresentMon elsewhere is left alone).
     private void KillOrphans()
     {
         try
         {
-            var full = Path.GetFullPath(_exePath);
+            var full = Path.GetFullPath(_runPath);
             foreach (var p in Process.GetProcessesByName("PresentMon"))
             {
                 try

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/PresentMonFpsProvider.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/PresentMonFpsProvider.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.InteropServices;
 
 namespace TouchPortalHardwareMonitor.Services;
 
@@ -28,6 +29,7 @@ public sealed class PresentMonFpsProvider : IDisposable
     private readonly ConcurrentDictionary<int, Entry> _entries = new();
 
     private Process? _proc;
+    private IntPtr _job = IntPtr.Zero;
     private int _pidCol = -1;
     private int _msCol = -1;
     private int _appCol = -1;
@@ -47,6 +49,11 @@ public sealed class PresentMonFpsProvider : IDisposable
             LastError = $"PresentMon.exe not found at {_exePath}";
             return false;
         }
+
+        // Clean up any copy of our bundled PresentMon left running by a previous
+        // plugin instance (e.g. after a hard kill), so it doesn't hold the ETW
+        // session or a file lock.
+        KillOrphans();
 
         try
         {
@@ -69,6 +76,14 @@ public sealed class PresentMonFpsProvider : IDisposable
             _proc.Exited += (_, _) => Running = false;
 
             _proc.Start();
+
+            // Tie PresentMon to a kill-on-close job object owned by this
+            // process. If the plugin dies for ANY reason - including Touch
+            // Portal hard-killing it on stop/re-import (which bypasses our
+            // graceful shutdown) - the OS closes the job handle and force-kills
+            // PresentMon, so it can't linger and lock its own .exe.
+            AssignToKillOnCloseJob(_proc);
+
             _proc.BeginOutputReadLine();
             _proc.BeginErrorReadLine();
             Running = true;
@@ -173,7 +188,122 @@ public sealed class PresentMonFpsProvider : IDisposable
         try { if (_proc is { HasExited: false }) _proc.Kill(true); } catch { }
         try { _proc?.Dispose(); } catch { }
         _proc = null;
+
+        // Closing the job handle also force-kills anything still in it.
+        if (_job != IntPtr.Zero)
+        {
+            try { CloseHandle(_job); } catch { }
+            _job = IntPtr.Zero;
+        }
     }
 
     public void Dispose() => Stop();
+
+    // Kill any leftover instance of *our* bundled PresentMon.exe (matched by
+    // full path, so a user's own PresentMon elsewhere is left alone).
+    private void KillOrphans()
+    {
+        try
+        {
+            var full = Path.GetFullPath(_exePath);
+            foreach (var p in Process.GetProcessesByName("PresentMon"))
+            {
+                try
+                {
+                    var path = p.MainModule?.FileName;
+                    if (path != null && string.Equals(Path.GetFullPath(path), full, StringComparison.OrdinalIgnoreCase))
+                    {
+                        p.Kill();
+                        p.WaitForExit(2000);
+                    }
+                }
+                catch { /* access denied / already gone */ }
+                finally { p.Dispose(); }
+            }
+        }
+        catch { }
+    }
+
+    private void AssignToKillOnCloseJob(Process proc)
+    {
+        try
+        {
+            _job = CreateJobObject(IntPtr.Zero, null);
+            if (_job == IntPtr.Zero) return;
+
+            var info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION();
+            info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+            int len = Marshal.SizeOf<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>();
+            IntPtr ptr = Marshal.AllocHGlobal(len);
+            try
+            {
+                Marshal.StructureToPtr(info, ptr, false);
+                SetInformationJobObject(_job, JobObjectExtendedLimitInformation, ptr, (uint)len);
+                AssignProcessToJobObject(_job, proc.Handle);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(ptr);
+            }
+        }
+        catch
+        {
+            // Best-effort; graceful shutdown + KillOrphans still cover most cases.
+        }
+    }
+
+    private const int JobObjectExtendedLimitInformation = 9;
+    private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string? lpName);
+
+    [DllImport("kernel32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetInformationJobObject(IntPtr hJob, int infoClass, IntPtr lpInfo, uint cbInfoLength);
+
+    [DllImport("kernel32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
+
+    [DllImport("kernel32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(IntPtr hObject);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IO_COUNTERS
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+    {
+        public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+        public IO_COUNTERS IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
 }

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/PresentMonFpsProvider.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/PresentMonFpsProvider.cs
@@ -141,6 +141,9 @@ public sealed class PresentMonFpsProvider : IDisposable
         if (!double.TryParse(f[_msCol], NumberStyles.Float, CultureInfo.InvariantCulture, out var ms)) return;
         if (ms <= 0 || double.IsNaN(ms) || double.IsInfinity(ms)) return;
 
+        // Skip the desktop compositor etc. - not a meaningful "game" FPS.
+        if (_appCol >= 0 && f.Length > _appCol && FpsService.IsExcludedApp(f[_appCol])) return;
+
         var entry = _entries.GetOrAdd(pid, _ => new Entry());
         // Smooth frametime so the reported FPS isn't jittery frame-to-frame.
         entry.EmaFrametimeMs = entry.EmaFrametimeMs <= 0 ? ms : (entry.EmaFrametimeMs * 0.8) + (ms * 0.2);
@@ -170,6 +173,7 @@ public sealed class PresentMonFpsProvider : IDisposable
         foreach (var kv in _entries)
         {
             if (now - kv.Value.LastTick > StaleMs || kv.Value.EmaFrametimeMs <= 0) continue;
+            if (FpsService.IsExcludedApp(kv.Value.Name)) continue;
             var fps = 1000.0 / kv.Value.EmaFrametimeMs;
             if (fps > bestFps)
             {

--- a/csharp-plugin/TouchPortalHardwareMonitor/TouchPortalHardwareMonitor.csproj
+++ b/csharp-plugin/TouchPortalHardwareMonitor/TouchPortalHardwareMonitor.csproj
@@ -13,7 +13,7 @@
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AssemblyName>TouchPortalHardwareMonitor</AssemblyName>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp-plugin/TouchPortalHardwareMonitor/entry.tp
+++ b/csharp-plugin/TouchPortalHardwareMonitor/entry.tp
@@ -1,6 +1,6 @@
 {
   "sdk": 6,
-  "version": 2200,
+  "version": 2201,
   "name": "Touch Portal Hardware Monitor",
   "id": "TP_HM",
   "plugin_start_cmd": "\"%TP_PLUGIN_FOLDER%TouchPortalHardwareMonitor\\TouchPortalHardwareMonitor-Launcher.exe\"",
@@ -36,10 +36,10 @@
       "maxLength":3
     },
     {
-      "name":"FPS Source (Off/RTSS/Built-in/Auto)",
+      "name":"FPS Source (Off/RTSS/PresentMon/Built-in/Auto)",
       "default":"Auto",
       "type":"text",
-      "maxLength":8
+      "maxLength":10
     }
   ],
   "categories": [

--- a/csharp-plugin/build.ps1
+++ b/csharp-plugin/build.ps1
@@ -8,9 +8,31 @@ $publishDir = "$projectDir\bin\Release\net10.0\win-x64\publish"
 $launcherPublishDir = "$launcherDir\bin\Release\net10.0\win-x64\publish"
 $installersDir = "$PSScriptRoot\Installers"
 $pluginName = "TouchPortalHardwareMonitor"
-$version = "2.2.0"
+$version = "2.2.1"
+
+# PresentMon (Intel, MIT) is bundled for the accurate FPS backend. The binary
+# is NOT committed to the repo - it's downloaded here into tools\ (gitignored)
+# on first build and copied into the package.
+$toolsDir = "$PSScriptRoot\tools"
+$presentMonVersion = "1.10.0"
+$presentMonExe = "$toolsDir\PresentMon.exe"
+$presentMonUrl = "https://github.com/GameTechDev/PresentMon/releases/download/v$presentMonVersion/PresentMon-$presentMonVersion-x64.exe"
 
 Write-Host "Building Touch Portal Hardware Monitor C# Plugin v$version..." -ForegroundColor Cyan
+
+# Ensure PresentMon is available (download once)
+if (-not (Test-Path $presentMonExe)) {
+    Write-Host "Downloading PresentMon $presentMonVersion..." -ForegroundColor Yellow
+    New-Item -ItemType Directory -Force -Path $toolsDir | Out-Null
+    try {
+        Invoke-WebRequest -Uri $presentMonUrl -OutFile $presentMonExe
+        Write-Host "PresentMon downloaded to $presentMonExe" -ForegroundColor Green
+    }
+    catch {
+        Write-Host "WARNING: Could not download PresentMon ($($_.Exception.Message))." -ForegroundColor Red
+        Write-Host "The PresentMon FPS backend will be unavailable in this build; RTSS/Built-in still work." -ForegroundColor Red
+    }
+}
 
 # Clean previous builds
 if (Test-Path $publishDir) {
@@ -45,6 +67,14 @@ Write-Host "Launcher build successful!" -ForegroundColor Green
 # Copy launcher to main publish directory
 Write-Host "Copying launcher to publish directory..." -ForegroundColor Yellow
 Copy-Item "$launcherPublishDir\TouchPortalHardwareMonitor-Launcher.exe" "$publishDir\"
+
+# Bundle PresentMon next to the plugin (if it was downloaded)
+if (Test-Path $presentMonExe) {
+    Write-Host "Bundling PresentMon..." -ForegroundColor Yellow
+    Copy-Item $presentMonExe "$publishDir\PresentMon.exe"
+} else {
+    Write-Host "PresentMon.exe not present - packaging without the PresentMon FPS backend." -ForegroundColor Yellow
+}
 
 # Create Installers directory
 if (-not (Test-Path $installersDir)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "touchportal-hardwaremonitor",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Touch Portal plugin to read data from LibreHardwareMonitor",
   "main": "src/index.js",
   "bin": "src/index.js",


### PR DESCRIPTION
Follow-up to the 2.2.0 FPS work — a user reported the **Built-in** backend returning wildly wrong values (15 → 1500). Root cause: the ETW counter matched *any* event whose name contained "present" across the fully-verbose DXGI/D3D9 providers, so it counted `PresentStop` too (~2×) plus overlay/other events, and it counts present *calls* (uncapped apps present far more than they display).

## Fixed the ETW "Built-in" backend
- Count exactly **one event per present** — `PresentStart` (`Opcode.Start`) only, not the "present" substring.
- Enable the providers at **Informational** level, not full Verbose.
- Documented honestly as an **approximate present-call rate** (over-reads uncapped apps).

## Added an accurate **PresentMon** backend
- `PresentMonFpsProvider` runs **Intel PresentMon** (bundled as `PresentMon.exe`) as a child process, parses its CSV stream, and computes per-process FPS from `msBetweenPresents` (EMA-smoothed), attributed to the foreground app.
- New **`PresentMon`** FPS source; `Auto` chain is now **RTSS → PresentMon → Built-in ETW**.
- Setting renamed to **`FPS Source (Off/RTSS/PresentMon/Built-in/Auto)`**.

## Packaging (no binary committed)
- `build.ps1` **downloads PresentMon 1.10.0 (MIT)** into `csharp-plugin/tools/` on first build and bundles it into the `.tpp`. The binary is **gitignored**, not committed. If the download is skipped, the plugin still builds — only the `PresentMon` source is unavailable.

## Testing
- `dotnet build -c Release`: 0 warnings, 0 errors.
- Full `build.ps1`: PresentMon downloads (0.4 MB), bundles into the `.tpp` (verified present alongside the plugin), version 2.2.1.
- Trimmed single-file publish **locates and launches** `PresentMon.exe`; non-elevated it fails gracefully and `Auto` falls through with no crash.

> ⚠️ **Still needs elevated, in-game validation** — I can't reproduce a presenting game here. Run `TouchPortalHardwareMonitor.exe --fps` from an elevated prompt with a game open to confirm PresentMon numbers; then we can make it the recommended default over RTSS if it holds up.

## Note
The `FPS Source` setting name changed, so existing users' saved value resets to `Auto` (default) — acceptable for a fresh feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)