### PR TITLE
2.2.2: AMD CPU temps (PawnIO + warm-up) + fix update check

### DIFF
--- a/csharp-plugin/Launcher/Launcher.csproj
+++ b/csharp-plugin/Launcher/Launcher.csproj
@@ -11,7 +11,7 @@
     <PublishTrimmed>true</PublishTrimmed>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <AssemblyName>TouchPortalHardwareMonitor-Launcher</AssemblyName>
-    <Version>2.2.1</Version>
+    <Version>2.2.2</Version>
   </PropertyGroup>
 
 </Project>

--- a/csharp-plugin/TouchPortalHardwareMonitor/JsonContext.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/JsonContext.cs
@@ -26,6 +26,7 @@ namespace TouchPortalHardwareMonitor;
 [JsonSerializable(typeof(TPCreateState))]
 [JsonSerializable(typeof(TPNotification))]
 [JsonSerializable(typeof(DiagnosticDump))]
+[JsonSerializable(typeof(GitHubRelease))]
 public partial class AppJsonContext : JsonSerializerContext
 {
 }

--- a/csharp-plugin/TouchPortalHardwareMonitor/Models/HardwareModels.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Models/HardwareModels.cs
@@ -43,6 +43,19 @@ public class SensorItem
     public SensorStateInfo? StateId { get; set; }
 }
 
+// Minimal shape of the GitHub "latest release" API response, for update checks.
+public class GitHubRelease
+{
+    [JsonPropertyName("tag_name")]
+    public string TagName { get; set; } = string.Empty;
+
+    [JsonPropertyName("prerelease")]
+    public bool Prerelease { get; set; }
+
+    [JsonPropertyName("html_url")]
+    public string HtmlUrl { get; set; } = string.Empty;
+}
+
 // A connected display, sourced from Win32 (not LibreHardwareMonitor).
 public class DisplayInfo
 {

--- a/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
@@ -231,11 +231,14 @@ class Program
     private const string PluginId = "TP_HM";
     private const string UpdateUrl = "https://raw.githubusercontent.com/spdermn02/TouchPortal-HardwareMonitor/main/package.json";
     private const string ReleaseUrl = "https://github.com/spdermn02/TouchPortal-HardwareMonitor/releases";
+    private const string PawnIoUrl = "https://pawnio.eu";
     private const int MaxWaitTime = 60000;
     private const int StartCaptureWaitTime = 2000;
 
     private static TouchPortalClient? _tpClient;
     private static HardwareMonitorService? _hwService;
+    private static PawnIoService? _pawnIo;
+    private static bool _pawnIoJustInstalled = false;
     private static readonly Dictionary<string, HardwareItem> _hardware = new();
 
     private static int _captureInterval = 2000;
@@ -477,6 +480,28 @@ class Program
             // Load persistent hardware mapping
             LoadHardwareMapping();
 
+            // Ensure the PawnIO kernel driver is present. LibreHardwareMonitor
+            // reads CPU temperatures/clocks/voltages through it; without it those
+            // sensors don't appear. Must run before LHM initializes.
+            _pawnIo = new PawnIoService();
+            var pawnResult = await _pawnIo.EnsureInstalledAsync(_isElevated, LogDebug);
+            switch (pawnResult)
+            {
+                case PawnIoResult.AlreadyInstalled:
+                    LogDebug("[PawnIO] driver already installed.");
+                    break;
+                case PawnIoResult.Installed:
+                    _pawnIoJustInstalled = true;
+                    Log("Installed the PawnIO kernel driver (required for CPU temperature/clock/voltage sensors). A Touch Portal restart is needed to activate them.");
+                    break;
+                case PawnIoResult.InstallFailed:
+                    Log($"PawnIO install failed: {_pawnIo.LastError} CPU temperature/clock/voltage sensors may be unavailable.");
+                    break;
+                case PawnIoResult.NotElevated:
+                    Log("Not elevated; skipping PawnIO install. CPU temperature/clock/voltage sensors may be unavailable.");
+                    break;
+            }
+
             // Initialize hardware monitor service
             Log("Initializing LibreHardwareMonitor...");
             _hwService = new HardwareMonitorService();
@@ -513,6 +538,13 @@ class Program
             Log("Connecting to Touch Portal...");
             await _tpClient.ConnectAsync();
             Log("Connected to Touch Portal");
+
+            // If we just installed PawnIO, let the user know via a Touch Portal
+            // notification (and that a restart is needed to activate CPU sensors).
+            if (_pawnIoJustInstalled)
+            {
+                SendPawnIoInstalledNotification();
+            }
 
             // Keep running
             await Task.Delay(Timeout.Infinite);
@@ -623,6 +655,33 @@ class Program
                 _tpClient?.LogIt("ERROR", $"Failed to open release URL: {ex.Message}");
             }
         }
+        else if (optionId == $"{PluginId}_pawnio_installed_learn_more")
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = PawnIoUrl,
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                _tpClient?.LogIt("ERROR", $"Failed to open PawnIO URL: {ex.Message}");
+            }
+        }
+    }
+
+    private static void SendPawnIoInstalledNotification()
+    {
+        _tpClient?.SendNotification(
+            $"{PluginId}_pawnio_installed",
+            "Hardware driver installed (PawnIO)",
+            "To read CPU temperatures, clocks and voltages, Touch Portal Hardware Monitor installed PawnIO - a signed, scriptable kernel driver that gives applications safe low-level hardware access (also used by tools like Fan Control and OpenRGB). It replaces the older WinRing0 driver that antivirus often flagged. Please restart Touch Portal to activate these sensors.",
+            new List<TPNotificationOption>
+            {
+                new() { Id = $"{PluginId}_pawnio_installed_learn_more", Title = "About PawnIO" }
+            });
     }
 
     private static async Task BuildHardwareList()

--- a/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
@@ -98,7 +98,7 @@ class Program
             var dump = new DiagnosticDump
             {
                 Timestamp = DateTime.Now.ToString("o"),
-                PluginVersion = "2.2.1",
+                PluginVersion = "2.2.2",
                 IsElevated = _isElevated,
                 SensorAccess = DetectSensorAccessStatus(rawSensorData).Message,
                 Settings = new DiagnosticSettings
@@ -446,7 +446,7 @@ class Program
             return;
         }
 
-        Log("Touch Portal Hardware Monitor v2.2.1 starting...");
+        Log("Touch Portal Hardware Monitor v2.2.2 starting...");
 
         // Initialize log level from file (before anything else)
         InitializeLogLevel();
@@ -632,11 +632,30 @@ class Program
 
         try
         {
+            // Warm up before discovery: AMD CPU temps (Tctl/Tdie, SoC, per-CCD)
+            // and delta-based clocks/power often need a few spaced updates before
+            // they read/enumerate, so a single startup read can miss them.
+            LogDebug("[Hardware] Warming up sensors...");
+            _hwService?.WarmUp();
+
             LogDebug("[Hardware] Calling _hwService.GetHardware()...");
             var hardwareData = _hwService?.GetHardware();
             var sensorData = _hwService?.GetSensors();
             LogDebug($"[Hardware] GetHardware returned: {hardwareData?.Count ?? -1} items");
             LogDebug($"[Hardware] GetSensors returned: {sensorData?.Count ?? -1} sensors");
+
+            // Surface CPU temperature discovery for diagnosing AMD/Intel temp gaps.
+            if (_debugLogging && sensorData != null)
+            {
+                var cpuTemps = sensorData
+                    .Where(s => s.SensorType == "Temperature" && s.Parent.Contains("cpu", StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+                LogDebug($"[Hardware] CPU temperature sensors after warm-up: {cpuTemps.Count}");
+                foreach (var t in cpuTemps)
+                {
+                    LogDebug($"[Hardware]   {t.Name} = {t.Value}");
+                }
+            }
 
             if (hardwareData == null || hardwareData.Count == 0)
             {

--- a/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Program.cs
@@ -98,7 +98,7 @@ class Program
             var dump = new DiagnosticDump
             {
                 Timestamp = DateTime.Now.ToString("o"),
-                PluginVersion = "2.2.2",
+                PluginVersion = CurrentVersion,
                 IsElevated = _isElevated,
                 SensorAccess = DetectSensorAccessStatus(rawSensorData).Message,
                 Settings = new DiagnosticSettings
@@ -229,7 +229,8 @@ class Program
     }
 
     private const string PluginId = "TP_HM";
-    private const string UpdateUrl = "https://raw.githubusercontent.com/spdermn02/TouchPortal-HardwareMonitor/main/package.json";
+    // Single source of truth for the running plugin version (dump, logs, update check).
+    private const string CurrentVersion = "2.2.2";
     private const string ReleaseUrl = "https://github.com/spdermn02/TouchPortal-HardwareMonitor/releases";
     private const string PawnIoUrl = "https://pawnio.eu";
     private const int MaxWaitTime = 60000;
@@ -239,6 +240,7 @@ class Program
     private static HardwareMonitorService? _hwService;
     private static PawnIoService? _pawnIo;
     private static bool _pawnIoJustInstalled = false;
+    private static readonly UpdateService _updateService = new();
     private static readonly Dictionary<string, HardwareItem> _hardware = new();
 
     private static int _captureInterval = 2000;
@@ -449,7 +451,7 @@ class Program
             return;
         }
 
-        Log("Touch Portal Hardware Monitor v2.2.2 starting...");
+        Log($"Touch Portal Hardware Monitor v{CurrentVersion} starting...");
 
         // Initialize log level from file (before anything else)
         InitializeLogLevel();
@@ -545,6 +547,9 @@ class Program
             {
                 SendPawnIoInstalledNotification();
             }
+
+            // Check for a newer release (non-blocking).
+            _ = CheckForUpdatesAsync();
 
             // Keep running
             await Task.Delay(Timeout.Infinite);
@@ -669,6 +674,30 @@ class Program
             {
                 _tpClient?.LogIt("ERROR", $"Failed to open PawnIO URL: {ex.Message}");
             }
+        }
+    }
+
+    private static async Task CheckForUpdatesAsync()
+    {
+        try
+        {
+            var newVersion = await _updateService.CheckForUpdateAsync(CurrentVersion, LogDebug);
+            if (!string.IsNullOrEmpty(newVersion))
+            {
+                Log($"Update available: {newVersion} (installed: {CurrentVersion})");
+                _tpClient?.SendNotification(
+                    $"{PluginId}_update_notification_{newVersion}",
+                    "Hardware Monitor Plugin Update Available",
+                    $"New Version: {newVersion}\n\nPlease update to get the latest bug fixes and new features.\n\nCurrent Installed Version: {CurrentVersion}",
+                    new List<TPNotificationOption>
+                    {
+                        new() { Id = $"{PluginId}_update_notification_go_to_download", Title = "Go To Download Location" }
+                    });
+            }
+        }
+        catch (Exception ex)
+        {
+            LogDebug($"[Update] check error: {ex.Message}");
         }
     }
 

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/HardwareMonitorService.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/HardwareMonitorService.cs
@@ -40,6 +40,39 @@ public class HardwareMonitorService : IDisposable
         return result;
     }
 
+    /// <summary>
+    /// Update all hardware a few times before the first discovery/capture.
+    /// Some values only appear after a warm-up: AMD CPU temperatures (Tctl/Tdie,
+    /// SoC, per-CCD) are read behind a short PCI-bus mutex and their CCD sensors
+    /// are created lazily only on a valid (non-zero) read, so a single early read
+    /// during app startup can miss them; and delta-based sensors (clocks, power)
+    /// need two spaced samples. Spacing the passes gives those reads a real
+    /// chance to succeed and populate.
+    /// </summary>
+    public void WarmUp(int passes = 3, int delayMs = 400)
+    {
+        for (int i = 0; i < passes; i++)
+        {
+            UpdateAll(_computer.Hardware);
+            if (i < passes - 1)
+            {
+                Thread.Sleep(delayMs);
+            }
+        }
+    }
+
+    private static void UpdateAll(IEnumerable<IHardware> hardwareList)
+    {
+        foreach (var hardware in hardwareList)
+        {
+            hardware.Update();
+            if (hardware.SubHardware.Length > 0)
+            {
+                UpdateAll(hardware.SubHardware);
+            }
+        }
+    }
+
     private void CollectHardware(IEnumerable<IHardware> hardwareList, List<HardwareItem> result)
     {
         foreach (var hardware in hardwareList)

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/PawnIoService.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/PawnIoService.cs
@@ -1,0 +1,111 @@
+using System.Diagnostics;
+using System.Net.Http;
+
+namespace TouchPortalHardwareMonitor.Services;
+
+public enum PawnIoResult
+{
+    AlreadyInstalled,
+    Installed,
+    InstallFailed,
+    NotElevated
+}
+
+/// <summary>
+/// Ensures the PawnIO kernel driver is present. LibreHardwareMonitor reads CPU
+/// MSR/SMN sensors (temperatures, clocks, voltages) through PawnIO; if it isn't
+/// installed those sensors are unavailable. We don't redistribute the installer
+/// (it has no declared license) - instead we fetch the official signed installer
+/// from namazso's pinned release and run it silently. Requires elevation.
+/// </summary>
+public sealed class PawnIoService
+{
+    private const string ServiceName = "PawnIO";
+    // Pinned official signed installer (github.com/namazso/PawnIO.Setup).
+    private const string InstallerUrl =
+        "https://github.com/namazso/PawnIO.Setup/releases/download/2.2.0/PawnIO_setup.exe";
+
+    public string? LastError { get; private set; }
+
+    /// <summary>True if the PawnIO kernel-mode service is registered.</summary>
+    public bool IsInstalled()
+    {
+        try
+        {
+            using var proc = Process.Start(new ProcessStartInfo
+            {
+                FileName = "sc.exe",
+                Arguments = $"query {ServiceName}",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            });
+            if (proc == null) return false;
+            var output = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit(5000);
+            return output.Contains("SERVICE_NAME", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<PawnIoResult> EnsureInstalledAsync(bool isElevated, Action<string>? log = null)
+    {
+        if (IsInstalled())
+        {
+            return PawnIoResult.AlreadyInstalled;
+        }
+
+        if (!isElevated)
+        {
+            LastError = "Cannot install PawnIO because the plugin is not running as administrator.";
+            return PawnIoResult.NotElevated;
+        }
+
+        var installer = Path.Combine(Path.GetTempPath(), "PawnIO_setup.exe");
+        try
+        {
+            log?.Invoke($"[PawnIO] downloading official installer from {InstallerUrl}");
+            using (var http = new HttpClient { Timeout = TimeSpan.FromSeconds(60) })
+            {
+                var bytes = await http.GetByteArrayAsync(InstallerUrl);
+                await File.WriteAllBytesAsync(installer, bytes);
+            }
+
+            log?.Invoke("[PawnIO] running installer (-install -silent)...");
+            using (var proc = Process.Start(new ProcessStartInfo
+            {
+                FileName = installer,
+                Arguments = "-install -silent",
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }))
+            {
+                if (proc != null)
+                {
+                    await proc.WaitForExitAsync();
+                }
+            }
+
+            if (IsInstalled())
+            {
+                return PawnIoResult.Installed;
+            }
+
+            LastError = "PawnIO installer finished but the service was not registered.";
+            return PawnIoResult.InstallFailed;
+        }
+        catch (Exception ex)
+        {
+            LastError = ex.Message;
+            return PawnIoResult.InstallFailed;
+        }
+        finally
+        {
+            try { File.Delete(installer); } catch { /* best effort */ }
+        }
+    }
+}

--- a/csharp-plugin/TouchPortalHardwareMonitor/Services/UpdateService.cs
+++ b/csharp-plugin/TouchPortalHardwareMonitor/Services/UpdateService.cs
@@ -1,0 +1,67 @@
+using System.Net.Http;
+using System.Text.Json;
+using TouchPortalHardwareMonitor.Models;
+
+namespace TouchPortalHardwareMonitor.Services;
+
+/// <summary>
+/// Checks for a newer plugin release. Uses the GitHub Releases API (the
+/// canonical source of releases) rather than package.json on main, which tracks
+/// the in-development version and drifts ahead of what's actually released.
+/// </summary>
+public sealed class UpdateService
+{
+    // /releases/latest excludes drafts and pre-releases, so this is the latest
+    // stable release tag (e.g. "v2.2.1").
+    private const string LatestReleaseApi =
+        "https://api.github.com/repos/spdermn02/TouchPortal-HardwareMonitor/releases/latest";
+
+    public string? LastError { get; private set; }
+
+    /// <summary>
+    /// Returns the newer version (e.g. "2.2.2") if the latest release is newer
+    /// than <paramref name="currentVersion"/>; otherwise null.
+    /// </summary>
+    public async Task<string?> CheckForUpdateAsync(string currentVersion, Action<string>? log = null)
+    {
+        try
+        {
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+            // GitHub requires a User-Agent; without it the API returns 403.
+            http.DefaultRequestHeaders.UserAgent.ParseAdd("TouchPortalHardwareMonitor");
+            http.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+
+            var json = await http.GetStringAsync(LatestReleaseApi);
+            var release = JsonSerializer.Deserialize(json, AppJsonContext.Default.GitHubRelease);
+            if (release == null || string.IsNullOrWhiteSpace(release.TagName))
+            {
+                return null;
+            }
+
+            var latest = ParseVersion(release.TagName);
+            var current = ParseVersion(currentVersion);
+            if (latest == null || current == null)
+            {
+                return null;
+            }
+
+            log?.Invoke($"[Update] current={current} latest={latest} (tag {release.TagName})");
+            return latest > current ? release.TagName.TrimStart('v', 'V') : null;
+        }
+        catch (Exception ex)
+        {
+            LastError = ex.Message;
+            log?.Invoke($"[Update] check failed: {ex.Message}");
+            return null;
+        }
+    }
+
+    // Parse a version like "v2.2.1" or "2.0.0-alpha-1" into a comparable Version.
+    private static Version? ParseVersion(string raw)
+    {
+        var s = raw.TrimStart('v', 'V');
+        int dash = s.IndexOf('-');
+        if (dash >= 0) s = s[..dash]; // drop pre-release suffix
+        return Version.TryParse(s, out var v) ? v : null;
+    }
+}

--- a/csharp-plugin/TouchPortalHardwareMonitor/TouchPortalHardwareMonitor.csproj
+++ b/csharp-plugin/TouchPortalHardwareMonitor/TouchPortalHardwareMonitor.csproj
@@ -13,7 +13,7 @@
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AssemblyName>TouchPortalHardwareMonitor</AssemblyName>
-    <Version>2.2.1</Version>
+    <Version>2.2.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp-plugin/TouchPortalHardwareMonitor/entry.tp
+++ b/csharp-plugin/TouchPortalHardwareMonitor/entry.tp
@@ -1,6 +1,6 @@
 {
   "sdk": 6,
-  "version": 2201,
+  "version": 2202,
   "name": "Touch Portal Hardware Monitor",
   "id": "TP_HM",
   "plugin_start_cmd": "\"%TP_PLUGIN_FOLDER%TouchPortalHardwareMonitor\\TouchPortalHardwareMonitor-Launcher.exe\"",

--- a/csharp-plugin/build.ps1
+++ b/csharp-plugin/build.ps1
@@ -8,7 +8,7 @@ $publishDir = "$projectDir\bin\Release\net10.0\win-x64\publish"
 $launcherPublishDir = "$launcherDir\bin\Release\net10.0\win-x64\publish"
 $installersDir = "$PSScriptRoot\Installers"
 $pluginName = "TouchPortalHardwareMonitor"
-$version = "2.2.1"
+$version = "2.2.2"
 
 # PresentMon (Intel, MIT) is bundled for the accurate FPS backend. The binary
 # is NOT committed to the repo - it's downloaded here into tools\ (gitignored)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "touchportal-hardwaremonitor",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Touch Portal plugin to read data from LibreHardwareMonitor",
   "main": "src/index.js",
   "bin": "src/index.js",


### PR DESCRIPTION
Version **2.2.2**. Three related fixes.

## 1. Install PawnIO on first run (fixes missing AMD/Intel CPU temps)
LibreHardwareMonitor reads CPU MSR/SMN sensors (temps/clocks/voltages) through the **PawnIO** kernel driver, which our self-contained plugin never installed (the affected AMD user only got temps after installing LHM, which provisions PawnIO).
- `PawnIoService`: detect via `sc query PawnIO`; if absent **and elevated**, download the **official signed** installer (`namazso/PawnIO.Setup`, pinned **2.2.0**) and run `-install -silent`. Runtime download, not redistributed (installer repo has no license). Runs before LHM init.
- **TP notification** on fresh install explaining PawnIO (signed kernel driver replacing the AV-flagged WinRing0) + that a **restart** is needed to activate CPU sensors (PawnIO's dir is added to PATH, which the running process won't see until relaunch). "About PawnIO" → pawnio.eu.
- Likely also resolves the earlier Memory-Integrity CPU-temp reports (PawnIO is HVCI-compatible).

## 2. Sensor warm-up (minor robustness)
`HardwareMonitorService.WarmUp()` — a few spaced updates before discovery so mutex-gated AMD temps + delta-based clocks/power populate instead of reading 0 on a single startup read. + DEBUG line listing CPU temp sensors/values.

## 3. Fix the "update available" check
It was never actually implemented in C# (the old JS plugin let the TP Node SDK poll `package.json` via `updateUrl`; only the constant + click-handler were ported). The old URL (`raw main/package.json`) is also wrong now — `main` tracks the dev version and drifts ahead of releases → false "update available".
- `UpdateService`: queries the **GitHub Releases API** (`/releases/latest`, excludes drafts/prereleases) and compares the latest tag to the running version; notifies (Go To Download → Releases page) if newer.
- Single `CurrentVersion` const now drives dump/log/update-check; removed the stale `UpdateUrl`.

## Testing
- `dotnet build`: clean; 2.2.2 `.tpp` built.
- PawnIO detection verified on a machine where it's installed (short-circuits). Update check verified against the live API (latest `v2.2.1`, correct comparison).
- **Needs validation on the AMD box without PawnIO:** install → notification appears → restart → Core/SoC/CCD temps show real values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)